### PR TITLE
fix(lint): honor overloads and bound static lookups

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -410,8 +410,8 @@ function uniqueTypesById(types: readonly CorsaType[]): readonly CorsaType[] {
  * Position-based type lookups resolve the touching token, so the direct query
  * for a call expression range yields the callee's type. Going through the
  * call signature mirrors what `checker.getTypeAtLocation(callExpr)` means in
- * the real TypeScript API. Overloads resolve to the first signature, which is
- * the same approximation the NewExpression path uses.
+ * the real TypeScript API. Overloads resolve through the argument-aware
+ * signature facts when the native checker can provide them.
  */
 function typeOfCallExpression(
   context: ContextWithParserOptions,
@@ -426,7 +426,15 @@ function typeOfCallExpression(
   if (!calleeType) {
     return undefined;
   }
-  const callSignature = checker.getSignaturesOfType(calleeType, SignatureKind.Call)[0];
+  const rawArgs = (node as unknown as { readonly arguments?: unknown }).arguments;
+  const args = Array.isArray(rawArgs) ? rawArgs.filter(isNode) : [];
+  const callSignature =
+    checker.getCallSignatureFacts(
+      calleeType,
+      SignatureKind.Call,
+      args.map((arg) => typeTextsAtCallArgument(context, arg, checker)),
+      explicitTypeArgumentTexts(context, node),
+    ).signature ?? checker.getSignaturesOfType(calleeType, SignatureKind.Call)[0];
   if (!callSignature) {
     return undefined;
   }
@@ -436,6 +444,73 @@ function typeOfCallExpression(
   }
   sessionForContext(context).session.rememberTypeLookupFromType(returnType, calleeType);
   return returnType;
+}
+
+function typeTextsAtCallArgument(
+  context: ContextWithParserOptions,
+  node: Node,
+  checker: CorsaTypeCheckerShape,
+): readonly string[] {
+  const values = new Set<string>();
+  const nodeType = checker.getTypeAtLocation(node);
+  collectTexts(nodeType ? (checker.getBaseTypeOfLiteralType(nodeType) ?? nodeType) : undefined);
+  const symbol = checker.getSymbolAtLocation(node);
+  const symbolType = symbol
+    ? (checker.getTypeOfSymbol(symbol) ?? checker.getDeclaredTypeOfSymbol(symbol))
+    : undefined;
+  collectTexts(
+    symbolType ? (checker.getBaseTypeOfLiteralType(symbolType) ?? symbolType) : undefined,
+  );
+  return [...values];
+
+  function collectTexts(type: CorsaType | undefined): void {
+    if (!type) {
+      return;
+    }
+    for (const text of [...(type.texts ?? []), safeTypeToString(checker, type) ?? ""]) {
+      if (text) {
+        values.add(text);
+      }
+    }
+  }
+}
+
+function explicitTypeArgumentTexts(
+  context: ContextWithParserOptions,
+  node: Node,
+): readonly string[] {
+  const explicitNodes = typeArgumentNodes(node as unknown as Record<string, unknown>);
+  if (explicitNodes.length > 0) {
+    return explicitNodes
+      .map((typeArgument) => context.sourceCode.getText(typeArgument as Node))
+      .filter((text): text is string => text.length > 0);
+  }
+  const callee = childNode(node, "callee");
+  const range = (node as Node & { readonly range?: readonly [number, number] }).range;
+  const calleeRange = (
+    callee as (Node & { readonly range?: readonly [number, number] }) | undefined
+  )?.range;
+  if (!range || !calleeRange) {
+    return [];
+  }
+  return typeArgumentRanges(context.sourceCode.text, calleeRange[1], range[1]).map(([start, end]) =>
+    context.sourceCode.text.slice(start, end),
+  );
+}
+
+function typeArgumentNodes(node: Record<string, unknown>): readonly Node[] {
+  const candidates = [
+    node.typeArguments,
+    node.typeParameters,
+    node.typeParameterInstantiation,
+  ].flatMap((candidate) => {
+    if (!candidate || typeof candidate !== "object") {
+      return [];
+    }
+    const params = (candidate as { readonly params?: unknown }).params;
+    return Array.isArray(params) ? params : [];
+  });
+  return candidates.filter(isNode);
 }
 
 /**

--- a/src/bindings/nodejs/corsa_oxlint/ts/native_rules.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/native_rules.test.ts
@@ -597,6 +597,16 @@ describe("corsa oxlint native rules", () => {
           code: "class Counter { static count() { return 1; } } const counted = Counter.count;",
           options: [{ ignoreStatic: true }],
         },
+        {
+          code: [
+            "class Counter { count() { return this; } }",
+            "class Other { static count() { return 1; } }",
+            "function take(Counter: typeof Other) {",
+            "  const counted = Counter.count;",
+            "}",
+          ].join("\n"),
+          options: [{ ignoreStatic: true }],
+        },
       ],
       invalid: [
         {

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/fact_providers.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/fact_providers.ts
@@ -748,7 +748,7 @@ function staticMemberFromAst(
       ) {
         continue;
       }
-      return member.static === true;
+      return classMemberHasStaticModifier(context, member);
     }
   }
   return undefined;
@@ -887,6 +887,18 @@ function sameFileDeclarationPositions(
 
 function rangeContains(node: any, position: number): boolean {
   return Array.isArray(node?.range) && node.range[0] <= position && position <= node.range[1];
+}
+
+function classMemberHasStaticModifier(context: ContextWithParserOptions, member: any): boolean {
+  if (member?.static === true) {
+    return true;
+  }
+  const rangeStart = Array.isArray(member?.range) ? member.range[0] : undefined;
+  const keyStart = Array.isArray(member?.key?.range) ? member.key.range[0] : undefined;
+  if (typeof rangeStart !== "number" || typeof keyStart !== "number" || keyStart < rangeStart) {
+    return false;
+  }
+  return /\bstatic\b/.test(context.sourceCode.text.slice(rangeStart, keyStart));
 }
 
 /**

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/fact_providers.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/fact_providers.ts
@@ -720,15 +720,22 @@ function staticMemberFromAst(
   }
   const objectSymbol = checkerFor(context).getSymbolAtLocation(memberExpression.object);
   const objectPositions = objectSymbol ? sameFileDeclarationPositions(context, objectSymbol) : [];
-  if (objectPositions.length === 0) {
+  const memberPositions = sameFileDeclarationPositions(context, symbol);
+  const bindingPositions = [...objectPositions, ...memberPositions];
+  const objectTypeMatchesClass = objectTypeReferencesClass(
+    context,
+    memberExpression.object,
+    objectName,
+  );
+  if (bindingPositions.length === 0 && !objectTypeMatchesClass) {
     return undefined;
   }
-  const memberPositions = sameFileDeclarationPositions(context, symbol);
-  const classNode = findClassDeclarationByNameAndPosition(
-    rootOf(memberExpression),
-    objectName,
-    objectPositions,
-  );
+  const root = rootOf(memberExpression);
+  const classNode =
+    (bindingPositions.length > 0
+      ? findClassDeclarationByNameAndPosition(root, objectName, bindingPositions)
+      : undefined) ??
+    (objectTypeMatchesClass ? uniqueClassDeclarationByName(root, objectName) : undefined);
   const members = Array.isArray(classNode?.body?.body) ? classNode.body.body : [];
   for (const member of members) {
     if (!member || typeof member !== "object") {
@@ -745,6 +752,25 @@ function staticMemberFromAst(
     }
   }
   return undefined;
+}
+
+function objectTypeReferencesClass(
+  context: ContextWithParserOptions,
+  node: any,
+  name: string,
+): boolean {
+  const type = typeAtNode(context, node);
+  if (!type) {
+    return false;
+  }
+  const expected = `typeof ${name}`;
+  const texts = new Set(type.texts ?? []);
+  try {
+    texts.add(checkerFor(context).typeToString(type));
+  } catch {
+    // Leave the AST fallback disabled when the class binding cannot be rendered.
+  }
+  return [...texts].some((text) => text.trim() === expected);
 }
 
 function identifierLikeName(node: any): string | undefined {
@@ -803,6 +829,37 @@ function findClassDeclarationByNameAndPosition(
     }
   }
   return undefined;
+}
+
+function uniqueClassDeclarationByName(root: any, name: string): any {
+  const matches: any[] = [];
+  collectClassDeclarationsByName(root, name, matches);
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+function collectClassDeclarationsByName(root: any, name: string, matches: any[]): void {
+  if (!root || typeof root !== "object") {
+    return;
+  }
+  if (
+    (root.type === "ClassDeclaration" || root.type === "ClassExpression") &&
+    root.id?.type === "Identifier" &&
+    root.id.name === name
+  ) {
+    matches.push(root);
+  }
+  if (Array.isArray(root)) {
+    for (const item of root) {
+      collectClassDeclarationsByName(item, name, matches);
+    }
+    return;
+  }
+  for (const [key, value] of Object.entries(root)) {
+    if (key === "parent" || value === null || typeof value !== "object") {
+      continue;
+    }
+    collectClassDeclarationsByName(value, name, matches);
+  }
 }
 
 function sameFileDeclarationPositions(

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/fact_providers.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/fact_providers.ts
@@ -19,7 +19,7 @@
 import { sessionForContext } from "../registry";
 import { memberPropertyName, stripChainExpression } from "./ast";
 import { checkerFor, typeAtNode, typeTextsAtNode } from "./type_utils";
-import type { ContextWithParserOptions, CorsaType } from "../types";
+import type { ContextWithParserOptions, CorsaSymbol, CorsaType } from "../types";
 
 /** Mutable sink the providers write resolved facts into. */
 export interface FactSink {
@@ -686,7 +686,8 @@ function unboundMethodInfoAt(
       thisArgIsVoid = thisTexts.length > 0 && thisTexts.every((text) => text.trim() === "void");
     }
   }
-  const isStatic = staticMemberFromAst(memberExpression) ?? staticModifierFor(context, symbol);
+  const isStatic =
+    staticMemberFromAst(context, memberExpression) ?? staticModifierFor(context, symbol);
   if (isMethod && ignoreStatic && isStatic === undefined) {
     // Reporting a static method that ignoreStatic excludes would be a false
     // positive, so degrade to silence when staticness is unknowable.
@@ -700,7 +701,10 @@ function unboundMethodInfoAt(
   };
 }
 
-function staticMemberFromAst(memberExpression: any): boolean | undefined {
+function staticMemberFromAst(
+  context: ContextWithParserOptions,
+  memberExpression: any,
+): boolean | undefined {
   if (
     !memberExpression ||
     memberExpression.type !== "MemberExpression" ||
@@ -713,7 +717,16 @@ function staticMemberFromAst(memberExpression: any): boolean | undefined {
   if (!propertyName || !objectName) {
     return undefined;
   }
-  const classNode = findClassDeclarationByName(rootOf(memberExpression), objectName);
+  const objectSymbol = checkerFor(context).getSymbolAtLocation(memberExpression.object);
+  const objectPositions = objectSymbol ? sameFileDeclarationPositions(context, objectSymbol) : [];
+  if (objectPositions.length === 0) {
+    return undefined;
+  }
+  const classNode = findClassDeclarationByNameAndPosition(
+    rootOf(memberExpression),
+    objectName,
+    objectPositions,
+  );
   const members = Array.isArray(classNode?.body?.body) ? classNode.body.body : [];
   for (const member of members) {
     if (!member || typeof member !== "object") {
@@ -747,20 +760,25 @@ function rootOf(node: any): any {
   return current;
 }
 
-function findClassDeclarationByName(root: any, name: string): any {
+function findClassDeclarationByNameAndPosition(
+  root: any,
+  name: string,
+  positions: readonly number[],
+): any {
   if (!root || typeof root !== "object") {
     return undefined;
   }
   if (
     (root.type === "ClassDeclaration" || root.type === "ClassExpression") &&
     root.id?.type === "Identifier" &&
-    root.id.name === name
+    root.id.name === name &&
+    positions.some((position) => rangeContains(root, position))
   ) {
     return root;
   }
   if (Array.isArray(root)) {
     for (const item of root) {
-      const match = findClassDeclarationByName(item, name);
+      const match = findClassDeclarationByNameAndPosition(item, name, positions);
       if (match) {
         return match;
       }
@@ -771,12 +789,39 @@ function findClassDeclarationByName(root: any, name: string): any {
     if (key === "parent" || value === null || typeof value !== "object") {
       continue;
     }
-    const match = findClassDeclarationByName(value, name);
+    const match = findClassDeclarationByNameAndPosition(value, name, positions);
     if (match) {
       return match;
     }
   }
   return undefined;
+}
+
+function sameFileDeclarationPositions(
+  context: ContextWithParserOptions,
+  symbol: CorsaSymbol,
+): readonly number[] {
+  const positions: number[] = [];
+  for (const declaration of [symbol.valueDeclaration, ...symbol.declarations]) {
+    if (!declaration) {
+      continue;
+    }
+    const [posPart, , ...pathParts] = declaration.split(".");
+    const path = pathParts.join(".");
+    const filename = String(context.filename ?? "");
+    if (!path || !(path === filename || filename.endsWith(path) || path.endsWith(filename))) {
+      continue;
+    }
+    const pos = Number(posPart);
+    if (Number.isFinite(pos) && pos >= 0 && pos <= context.sourceCode.text.length) {
+      positions.push(pos);
+    }
+  }
+  return positions;
+}
+
+function rangeContains(node: any, position: number): boolean {
+  return Array.isArray(node?.range) && node.range[0] <= position && position <= node.range[1];
 }
 
 /**

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/fact_providers.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/fact_providers.ts
@@ -687,7 +687,7 @@ function unboundMethodInfoAt(
     }
   }
   const isStatic =
-    staticMemberFromAst(context, memberExpression) ?? staticModifierFor(context, symbol);
+    staticMemberFromAst(context, symbol, memberExpression) ?? staticModifierFor(context, symbol);
   if (isMethod && ignoreStatic && isStatic === undefined) {
     // Reporting a static method that ignoreStatic excludes would be a false
     // positive, so degrade to silence when staticness is unknowable.
@@ -703,6 +703,7 @@ function unboundMethodInfoAt(
 
 function staticMemberFromAst(
   context: ContextWithParserOptions,
+  symbol: CorsaSymbol,
   memberExpression: any,
 ): boolean | undefined {
   if (
@@ -722,6 +723,7 @@ function staticMemberFromAst(
   if (objectPositions.length === 0) {
     return undefined;
   }
+  const memberPositions = sameFileDeclarationPositions(context, symbol);
   const classNode = findClassDeclarationByNameAndPosition(
     rootOf(memberExpression),
     objectName,
@@ -733,6 +735,12 @@ function staticMemberFromAst(
       continue;
     }
     if (identifierLikeName(member.key) === propertyName) {
+      if (
+        memberPositions.length > 0 &&
+        !memberPositions.some((position) => rangeContains(member, position))
+      ) {
+        continue;
+      }
       return member.static === true;
     }
   }

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/fact_providers.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/fact_providers.ts
@@ -718,9 +718,32 @@ function staticMemberFromAst(
   if (!propertyName || !objectName) {
     return undefined;
   }
+  const lexicalStatic = lexicalClassStaticMember(
+    context,
+    memberExpression,
+    objectName,
+    propertyName,
+  );
+  if (lexicalStatic !== undefined) {
+    return lexicalStatic;
+  }
   const objectSymbol = checkerFor(context).getSymbolAtLocation(memberExpression.object);
   const objectPositions = objectSymbol ? sameFileDeclarationPositions(context, objectSymbol) : [];
   const memberPositions = sameFileDeclarationPositions(context, symbol);
+  const root = rootOf(memberExpression);
+  const memberClass =
+    memberPositions.length > 0
+      ? findClassDeclarationContainingMember(root, propertyName, memberPositions)
+      : undefined;
+  if (memberClass) {
+    const className = identifierLikeName(memberClass.id);
+    const objectMatchesClass =
+      objectPositions.some((position) => rangeContains(memberClass, position)) ||
+      (className ? objectTypeReferencesClass(context, memberExpression.object, className) : false);
+    return objectMatchesClass
+      ? (classMemberStaticness(context, memberClass, propertyName) ?? false)
+      : false;
+  }
   const bindingPositions = [...objectPositions, ...memberPositions];
   const objectTypeMatchesClass = objectTypeReferencesClass(
     context,
@@ -730,7 +753,6 @@ function staticMemberFromAst(
   if (bindingPositions.length === 0 && !objectTypeMatchesClass) {
     return undefined;
   }
-  const root = rootOf(memberExpression);
   const classNode =
     (bindingPositions.length > 0
       ? findClassDeclarationByNameAndPosition(root, objectName, bindingPositions)
@@ -749,6 +771,45 @@ function staticMemberFromAst(
         continue;
       }
       return classMemberHasStaticModifier(context, member);
+    }
+  }
+  return undefined;
+}
+
+function findClassDeclarationContainingMember(
+  root: any,
+  propertyName: string,
+  positions: readonly number[],
+): any {
+  if (!root || typeof root !== "object") {
+    return undefined;
+  }
+  if (root.type === "ClassDeclaration" || root.type === "ClassExpression") {
+    for (const member of root.body?.body ?? []) {
+      if (
+        identifierLikeName(member?.key) === propertyName &&
+        positions.some((position) => rangeContains(member, position))
+      ) {
+        return root;
+      }
+    }
+  }
+  if (Array.isArray(root)) {
+    for (const item of root) {
+      const match = findClassDeclarationContainingMember(item, propertyName, positions);
+      if (match) {
+        return match;
+      }
+    }
+    return undefined;
+  }
+  for (const [key, value] of Object.entries(root)) {
+    if (key === "parent" || value === null || typeof value !== "object") {
+      continue;
+    }
+    const match = findClassDeclarationContainingMember(value, propertyName, positions);
+    if (match) {
+      return match;
     }
   }
   return undefined;
@@ -899,6 +960,147 @@ function classMemberHasStaticModifier(context: ContextWithParserOptions, member:
     return false;
   }
   return /\bstatic\b/.test(context.sourceCode.text.slice(rangeStart, keyStart));
+}
+
+function lexicalClassStaticMember(
+  context: ContextWithParserOptions,
+  memberExpression: any,
+  objectName: string,
+  propertyName: string,
+): boolean | undefined {
+  for (let scope = memberExpression.parent; scope; scope = scope.parent) {
+    const classNode = classBindingInScope(scope, objectName, memberExpression.range?.[0]);
+    if (classNode !== undefined) {
+      return classMemberStaticness(context, classNode, propertyName);
+    }
+    if (hasNonClassBindingInScope(scope, objectName, memberExpression.range?.[0])) {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function classBindingInScope(scope: any, name: string, before: number | undefined): any {
+  const statements = Array.isArray(scope?.body)
+    ? scope.body
+    : Array.isArray(scope?.body?.body)
+      ? scope.body.body
+      : [];
+  for (const statement of statements) {
+    if (!statementBefore(statement, before)) {
+      continue;
+    }
+    if (statement?.type === "ClassDeclaration" && statement.id?.name === name) {
+      return statement;
+    }
+    if (statement?.type !== "VariableDeclaration") {
+      continue;
+    }
+    for (const declarator of statement.declarations ?? []) {
+      if (
+        declarator?.id?.type === "Identifier" &&
+        declarator.id.name === name &&
+        (declarator.init?.type === "ClassExpression" ||
+          declarator.init?.type === "ClassDeclaration")
+      ) {
+        return declarator.init;
+      }
+    }
+  }
+  return undefined;
+}
+
+function hasNonClassBindingInScope(scope: any, name: string, before: number | undefined): boolean {
+  if (isFunctionLikeNode(scope)) {
+    for (const parameter of scope.params ?? []) {
+      if (bindingPatternContainsName(parameter, name)) {
+        return true;
+      }
+    }
+  }
+  if (scope?.type === "CatchClause" && bindingPatternContainsName(scope.param, name)) {
+    return true;
+  }
+  const statements = Array.isArray(scope?.body)
+    ? scope.body
+    : Array.isArray(scope?.body?.body)
+      ? scope.body.body
+      : [];
+  for (const statement of statements) {
+    if (!statementBefore(statement, before)) {
+      continue;
+    }
+    if (statement?.type === "FunctionDeclaration" && statement.id?.name === name) {
+      return true;
+    }
+    if (statement?.type !== "VariableDeclaration") {
+      continue;
+    }
+    for (const declarator of statement.declarations ?? []) {
+      if (
+        bindingPatternContainsName(declarator?.id, name) &&
+        declarator?.init?.type !== "ClassExpression" &&
+        declarator?.init?.type !== "ClassDeclaration"
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function classMemberStaticness(
+  context: ContextWithParserOptions,
+  classNode: any,
+  propertyName: string,
+): boolean | undefined {
+  for (const member of classNode?.body?.body ?? []) {
+    if (identifierLikeName(member?.key) === propertyName) {
+      return classMemberHasStaticModifier(context, member);
+    }
+  }
+  return undefined;
+}
+
+function statementBefore(statement: any, before: number | undefined): boolean {
+  if (before === undefined || !Array.isArray(statement?.range)) {
+    return true;
+  }
+  return statement.range[0] <= before;
+}
+
+function isFunctionLikeNode(node: any): boolean {
+  return (
+    node?.type === "FunctionDeclaration" ||
+    node?.type === "FunctionExpression" ||
+    node?.type === "ArrowFunctionExpression"
+  );
+}
+
+function bindingPatternContainsName(pattern: any, name: string): boolean {
+  if (!pattern || typeof pattern !== "object") {
+    return false;
+  }
+  if (pattern.type === "Identifier") {
+    return pattern.name === name;
+  }
+  if (pattern.type === "AssignmentPattern") {
+    return bindingPatternContainsName(pattern.left, name);
+  }
+  if (pattern.type === "RestElement") {
+    return bindingPatternContainsName(pattern.argument, name);
+  }
+  if (pattern.type === "ArrayPattern") {
+    return (pattern.elements ?? []).some((element: any) =>
+      bindingPatternContainsName(element, name),
+    );
+  }
+  if (pattern.type === "ObjectPattern") {
+    return (pattern.properties ?? []).some((property: any) =>
+      bindingPatternContainsName(property?.value ?? property?.argument, name),
+    );
+  }
+  return false;
 }
 
 /**

--- a/src/bindings/nodejs/corsa_oxlint/ts/rules/fact_providers.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/rules/fact_providers.ts
@@ -727,10 +727,19 @@ function staticMemberFromAst(
   if (lexicalStatic !== undefined) {
     return lexicalStatic;
   }
+  const root = rootOf(memberExpression);
+  const typeBackedStatic = staticMemberFromObjectType(
+    context,
+    memberExpression.object,
+    root,
+    propertyName,
+  );
+  if (typeBackedStatic !== undefined) {
+    return typeBackedStatic;
+  }
   const objectSymbol = checkerFor(context).getSymbolAtLocation(memberExpression.object);
   const objectPositions = objectSymbol ? sameFileDeclarationPositions(context, objectSymbol) : [];
   const memberPositions = sameFileDeclarationPositions(context, symbol);
-  const root = rootOf(memberExpression);
   const memberClass =
     memberPositions.length > 0
       ? findClassDeclarationContainingMember(root, propertyName, memberPositions)
@@ -813,6 +822,46 @@ function findClassDeclarationContainingMember(
     }
   }
   return undefined;
+}
+
+function staticMemberFromObjectType(
+  context: ContextWithParserOptions,
+  objectNode: any,
+  root: any,
+  propertyName: string,
+): boolean | undefined {
+  for (const className of objectTypeClassNames(context, objectNode)) {
+    const classNode = uniqueClassDeclarationByName(root, className);
+    const staticness = classNode
+      ? classMemberStaticness(context, classNode, propertyName)
+      : undefined;
+    if (staticness !== undefined) {
+      return staticness;
+    }
+  }
+  return undefined;
+}
+
+function objectTypeClassNames(context: ContextWithParserOptions, node: any): readonly string[] {
+  const type = typeAtNode(context, node);
+  if (!type) {
+    return [];
+  }
+  const checker = checkerFor(context);
+  const texts = new Set(type.texts ?? []);
+  try {
+    texts.add(checker.typeToString(type));
+  } catch {
+    // Fall back to any text that came with the type handle.
+  }
+  const names = new Set<string>();
+  for (const text of texts) {
+    const match = /^typeof\s+([A-Za-z_$][\w$]*)$/.exec(text.trim());
+    if (match) {
+      names.add(match[1]);
+    }
+  }
+  return [...names];
 }
 
 function objectTypeReferencesClass(

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -604,6 +604,72 @@ describe("corsa oxlint type locations", () => {
     expect(seen.object).toBe("typeof Foo");
   });
 
+  integrationCase("resolves overloaded call expression return types from arguments", () => {
+    const seen: Record<string, string | undefined> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "overloaded-call-expression-type",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise argument-aware call expression type lookup",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          CallExpression(node: any) {
+            if (node.callee?.name !== "choose") {
+              return;
+            }
+            const argument = node.arguments?.[0];
+            const key = typeof argument?.value === "number" ? "number" : "string";
+            const type = checker.getTypeAtLocation(node);
+            seen[key] = type ? checker.typeToString(type) : undefined;
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("overloaded-call-expression-type", rule as any, {
+      valid: [
+        {
+          code: [
+            "function choose(value: string): string;",
+            "function choose(value: number): number;",
+            "function choose(value: string | number): string | number {",
+            "  return value;",
+            "}",
+            "const text = choose('x');",
+            "const count = choose(1);",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                  mode: "jsonrpc",
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.string).toBe("string");
+    expect(seen.number).toBe("number");
+  });
+
   integrationCase("falls back for instantiated generic base types", () => {
     const seen: Record<string, readonly string[] | undefined> = {};
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);


### PR DESCRIPTION
## Summary
- resolve call expression return types with argument-aware signature facts before falling back to the first signature
- bind the unbound-method static AST fallback to the resolved object symbol before trusting same-file class metadata
- add regressions for overload return selection and ignoreStatic shadowing

## Verification
- vp check
- CORSA_REQUIRE_INTEGRATION=1 vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts src/bindings/nodejs/corsa_oxlint/ts/native_rules.test.ts
- CORSA_REQUIRE_INTEGRATION=1 vp run -w test_ts

Follow-up to #465 for CodeRabbit comments that landed after #465 had already merged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790341149&installation_model_id=422833&pr_number=466&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F466&signature=cd6fe3d0f631dd65a5b6a618a560d4a8f02800e7aee61a466a8d633708259b3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->