### PR TITLE
feat(napi): expose batched symbol and alias queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ published versions.
 - the Node binding exposes named sync/async wrappers for project-scoped
   `getSymbolsAtPositions`, `getAliasedSymbol`, and
   `getImmediateAliasedSymbol`, avoiding untyped `callJson` calls on common
-  symbol-resolution hot paths.
+  symbol-resolution hot paths. The same facade now exposes
+  `getExportsOfModule` for checker-owned module export enumeration.
 - full typescript-eslint option parity for the native rule set, including `ignoreVoid`/`ignoreIIFE`/`checkThenables`/`allowForKnownSafeCalls`/`allowForKnownSafePromises` (no-floating-promises), `allow`/`allowRethrowing`/`allowThrowingAny`/`allowThrowingUnknown` (only-throw-error), `checkUnknown`/`ignoredTypeNames` (no-base-to-string), `allow` lists for restrict-template-expressions, prefer-promise-reject-errors, and prefer-readonly-parameter-types (plus `treatMethodsAsReadonly`), `allowSingleElementEquality` with the `s[0] === "a"` detection family (prefer-string-starts-ends-with), and `defaultCaseCommentPattern` (switch-exhaustiveness-check). [`docs/typescript_eslint_parity.md`](./docs/typescript_eslint_parity.md) tracks the per-rule status.
 - `no-floating-promises` and `only-throw-error` moved to the upstream message catalogs (`floating*`, `object`/`undef`); their previous local `unexpected` IDs no longer exist.
 - the corsa-oxlint checker shim exposes `getJsDocTags` and `isTypeAssignableTo`, backed by the corresponding upstream endpoints with per-snapshot caching.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ published versions.
 
 ### Added
 
+- the Node binding exposes named sync/async wrappers for project-scoped
+  `getSymbolsAtPositions`, `getAliasedSymbol`, and
+  `getImmediateAliasedSymbol`, avoiding untyped `callJson` calls on common
+  symbol-resolution hot paths.
 - full typescript-eslint option parity for the native rule set, including `ignoreVoid`/`ignoreIIFE`/`checkThenables`/`allowForKnownSafeCalls`/`allowForKnownSafePromises` (no-floating-promises), `allow`/`allowRethrowing`/`allowThrowingAny`/`allowThrowingUnknown` (only-throw-error), `checkUnknown`/`ignoredTypeNames` (no-base-to-string), `allow` lists for restrict-template-expressions, prefer-promise-reject-errors, and prefer-readonly-parameter-types (plus `treatMethodsAsReadonly`), `allowSingleElementEquality` with the `s[0] === "a"` detection family (prefer-string-starts-ends-with), and `defaultCaseCommentPattern` (switch-exhaustiveness-check). [`docs/typescript_eslint_parity.md`](./docs/typescript_eslint_parity.md) tracks the per-rule status.
 - `no-floating-promises` and `only-throw-error` moved to the upstream message catalogs (`floating*`, `object`/`undef`); their previous local `unexpected` IDs no longer exist.
 - the corsa-oxlint checker shim exposes `getJsDocTags` and `isTypeAssignableTo`, backed by the corresponding upstream endpoints with per-snapshot caching.

--- a/docs/nodejs_binding.md
+++ b/docs/nodejs_binding.md
@@ -161,11 +161,17 @@ All of these have `*Async` counterparts.
 | `getStringType(snapshot, project)`                       | `TypeResponse`                                 |
 | `getTypeAtPosition(snapshot, project, file, position)`   | `TypeResponse \| null`                         |
 | `getSymbolAtPosition(snapshot, project, file, position)` | symbol response                                |
+| `getSymbolsAtPositions(snapshot, project, file, positions)` | symbol response list                        |
+| `getAliasedSymbol(snapshot, project, symbol)`            | fully resolved symbol or unknown symbol        |
+| `getImmediateAliasedSymbol(snapshot, project, symbol)`   | next alias target or `null`                     |
 | `getTypeArguments(snapshot, project, type)`              | type list                                      |
 | `getTypeOfSymbol(snapshot, project, symbol)`             | `TypeResponse \| null`                         |
 | `getDeclaredTypeOfSymbol(snapshot, project, symbol)`     | `TypeResponse \| null`                         |
 | `typeToString(snapshot, project, type)`                  | `string`                                       |
 
+The batch form performs one checker round trip for all positions in one source
+file. Alias methods require an alias symbol handle; check the returned symbol's
+flags before calling `getAliasedSymbol`, matching the upstream checker contract.
 For endpoints without a typed wrapper, drop down to the raw calls below.
 
 ## Raw calls (escape hatch)

--- a/docs/nodejs_binding.md
+++ b/docs/nodejs_binding.md
@@ -152,26 +152,28 @@ always `close()` the client.
 
 All of these have `*Async` counterparts.
 
-| Method                                                   | Returns                                        |
-| -------------------------------------------------------- | ---------------------------------------------- |
-| `initialize()`                                           | `InitializeResponse` (e.g. `currentDirectory`) |
-| `parseConfigFile(file)`                                  | `ConfigResponse`                               |
-| `updateSnapshot(params?)`                                | `{ snapshot, projects }`                       |
-| `getSourceFile(snapshot, project, file)`                 | `Buffer \| null`                               |
-| `getStringType(snapshot, project)`                       | `TypeResponse`                                 |
-| `getTypeAtPosition(snapshot, project, file, position)`   | `TypeResponse \| null`                         |
-| `getSymbolAtPosition(snapshot, project, file, position)` | symbol response                                |
-| `getSymbolsAtPositions(snapshot, project, file, positions)` | symbol response list                        |
-| `getAliasedSymbol(snapshot, project, symbol)`            | fully resolved symbol or unknown symbol        |
-| `getImmediateAliasedSymbol(snapshot, project, symbol)`   | next alias target or `null`                     |
-| `getTypeArguments(snapshot, project, type)`              | type list                                      |
-| `getTypeOfSymbol(snapshot, project, symbol)`             | `TypeResponse \| null`                         |
-| `getDeclaredTypeOfSymbol(snapshot, project, symbol)`     | `TypeResponse \| null`                         |
-| `typeToString(snapshot, project, type)`                  | `string`                                       |
+| Method                                                      | Returns                                        |
+| ----------------------------------------------------------- | ---------------------------------------------- |
+| `initialize()`                                              | `InitializeResponse` (e.g. `currentDirectory`) |
+| `parseConfigFile(file)`                                     | `ConfigResponse`                               |
+| `updateSnapshot(params?)`                                   | `{ snapshot, projects }`                       |
+| `getSourceFile(snapshot, project, file)`                    | `Buffer \| null`                               |
+| `getStringType(snapshot, project)`                          | `TypeResponse`                                 |
+| `getTypeAtPosition(snapshot, project, file, position)`      | `TypeResponse \| null`                         |
+| `getSymbolAtPosition(snapshot, project, file, position)`    | symbol response                                |
+| `getSymbolsAtPositions(snapshot, project, file, positions)` | symbol response list                           |
+| `getAliasedSymbol(snapshot, project, symbol)`               | fully resolved symbol or unknown symbol        |
+| `getImmediateAliasedSymbol(snapshot, project, symbol)`      | next alias target or `null`                    |
+| `getExportsOfModule(snapshot, project, symbol)`             | checker-owned module exports                   |
+| `getTypeArguments(snapshot, project, type)`                 | type list                                      |
+| `getTypeOfSymbol(snapshot, project, symbol)`                | `TypeResponse \| null`                         |
+| `getDeclaredTypeOfSymbol(snapshot, project, symbol)`        | `TypeResponse \| null`                         |
+| `typeToString(snapshot, project, type)`                     | `string`                                       |
 
 The batch form performs one checker round trip for all positions in one source
 file. Alias methods require an alias symbol handle; check the returned symbol's
 flags before calling `getAliasedSymbol`, matching the upstream checker contract.
+Module exports likewise use the checker symbol handle rather than a source name.
 For endpoints without a typed wrapper, drop down to the raw calls below.
 
 ## Raw calls (escape hatch)

--- a/src/bindings/nodejs/corsa_node/index.d.ts
+++ b/src/bindings/nodejs/corsa_node/index.d.ts
@@ -43,6 +43,9 @@ export declare class CorsaApiClient {
   /** Follows one alias edge for a checker symbol in its owning project. */
   getImmediateAliasedSymbol(snapshot: string, project: string, symbol: string): any
   getImmediateAliasedSymbolAsync(snapshot: string, project: string, symbol: string): Promise<unknown>
+  /** Returns the checker-owned exports of a module symbol. */
+  getExportsOfModule(snapshot: string, project: string, symbol: string): any
+  getExportsOfModuleAsync(snapshot: string, project: string, symbol: string): Promise<unknown>
   /**
    * Resolves the symbol attached to a checker type.
    *

--- a/src/bindings/nodejs/corsa_node/index.d.ts
+++ b/src/bindings/nodejs/corsa_node/index.d.ts
@@ -34,6 +34,15 @@ export declare class CorsaApiClient {
   /** Resolves the checker symbol visible at a file position. */
   getSymbolAtPosition(snapshot: string, project: string, file: string, position: number): any
   getSymbolAtPositionAsync(snapshot: string, project: string, file: string, position: number): Promise<unknown>
+  /** Resolves checker symbols for source positions in one project-scoped request. */
+  getSymbolsAtPositions(snapshot: string, project: string, file: string, positions: Array<number>): any
+  getSymbolsAtPositionsAsync(snapshot: string, project: string, file: string, positions: Array<number>): Promise<unknown>
+  /** Follows all aliases for a checker symbol in its owning project. */
+  getAliasedSymbol(snapshot: string, project: string, symbol: string): any
+  getAliasedSymbolAsync(snapshot: string, project: string, symbol: string): Promise<unknown>
+  /** Follows one alias edge for a checker symbol in its owning project. */
+  getImmediateAliasedSymbol(snapshot: string, project: string, symbol: string): any
+  getImmediateAliasedSymbolAsync(snapshot: string, project: string, symbol: string): Promise<unknown>
   /**
    * Resolves the symbol attached to a checker type.
    *

--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -208,6 +208,11 @@ enum JsonTaskKind {
         symbol: String,
         immediate: bool,
     },
+    GetExportsOfModule {
+        snapshot: String,
+        project: String,
+        symbol: String,
+    },
     GetSymbolOfType {
         snapshot: String,
         type_handle: String,
@@ -389,6 +394,19 @@ impl<'task> ScopedTask<'task> for JsonApiTask {
                         SymbolHandle::from(symbol.as_str()),
                     ))
                 }
+                .map_err(into_napi_error)?;
+                to_value(&response)
+            }
+            JsonTaskKind::GetExportsOfModule {
+                snapshot,
+                project,
+                symbol,
+            } => {
+                let response = block_on(self.client.get_exports_of_module(
+                    SnapshotHandle::from(snapshot.as_str()),
+                    ProjectHandle::from(project.as_str()),
+                    SymbolHandle::from(symbol.as_str()),
+                ))
                 .map_err(into_napi_error)?;
                 to_value(&response)
             }
@@ -1013,6 +1031,40 @@ impl CorsaApiClient {
                 project,
                 symbol,
                 immediate: true,
+            },
+        })
+    }
+
+    /// Returns the checker-owned exports of a module symbol.
+    #[napi]
+    pub fn get_exports_of_module(
+        &self,
+        snapshot: String,
+        project: String,
+        symbol: String,
+    ) -> Result<Value> {
+        let response = block_on(self.inner.get_exports_of_module(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            SymbolHandle::from(symbol.as_str()),
+        ))
+        .map_err(into_napi_error)?;
+        to_value(&response)
+    }
+
+    #[napi]
+    pub fn get_exports_of_module_async(
+        &self,
+        snapshot: String,
+        project: String,
+        symbol: String,
+    ) -> AsyncTask<JsonApiTask> {
+        AsyncTask::new(JsonApiTask {
+            client: self.inner.clone(),
+            kind: JsonTaskKind::GetExportsOfModule {
+                snapshot,
+                project,
+                symbol,
             },
         })
     }

--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -196,6 +196,18 @@ enum JsonTaskKind {
         file: String,
         position: u32,
     },
+    GetSymbolsAtPositions {
+        snapshot: String,
+        project: String,
+        file: String,
+        positions: Vec<u32>,
+    },
+    GetAliasedSymbol {
+        snapshot: String,
+        project: String,
+        symbol: String,
+        immediate: bool,
+    },
     GetSymbolOfType {
         snapshot: String,
         type_handle: String,
@@ -340,6 +352,43 @@ impl<'task> ScopedTask<'task> for JsonApiTask {
                     file.clone(),
                     *position,
                 ))
+                .map_err(into_napi_error)?;
+                to_value(&response)
+            }
+            JsonTaskKind::GetSymbolsAtPositions {
+                snapshot,
+                project,
+                file,
+                positions,
+            } => {
+                let response = block_on(self.client.get_symbols_at_positions(
+                    SnapshotHandle::from(snapshot.as_str()),
+                    ProjectHandle::from(project.as_str()),
+                    file.clone(),
+                    positions.clone(),
+                ))
+                .map_err(into_napi_error)?;
+                to_value(&response)
+            }
+            JsonTaskKind::GetAliasedSymbol {
+                snapshot,
+                project,
+                symbol,
+                immediate,
+            } => {
+                let response = if *immediate {
+                    block_on(self.client.get_immediate_aliased_symbol(
+                        SnapshotHandle::from(snapshot.as_str()),
+                        ProjectHandle::from(project.as_str()),
+                        SymbolHandle::from(symbol.as_str()),
+                    ))
+                } else {
+                    block_on(self.client.get_aliased_symbol(
+                        SnapshotHandle::from(snapshot.as_str()),
+                        ProjectHandle::from(project.as_str()),
+                        SymbolHandle::from(symbol.as_str()),
+                    ))
+                }
                 .map_err(into_napi_error)?;
                 to_value(&response)
             }
@@ -856,6 +905,114 @@ impl CorsaApiClient {
                 project,
                 file,
                 position,
+            },
+        })
+    }
+
+    /// Resolves checker symbols for source positions in one project-scoped request.
+    #[napi]
+    pub fn get_symbols_at_positions(
+        &self,
+        snapshot: String,
+        project: String,
+        file: String,
+        positions: Vec<u32>,
+    ) -> Result<Value> {
+        let response = block_on(self.inner.get_symbols_at_positions(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            file,
+            positions,
+        ))
+        .map_err(into_napi_error)?;
+        to_value(&response)
+    }
+
+    #[napi]
+    pub fn get_symbols_at_positions_async(
+        &self,
+        snapshot: String,
+        project: String,
+        file: String,
+        positions: Vec<u32>,
+    ) -> AsyncTask<JsonApiTask> {
+        AsyncTask::new(JsonApiTask {
+            client: self.inner.clone(),
+            kind: JsonTaskKind::GetSymbolsAtPositions {
+                snapshot,
+                project,
+                file,
+                positions,
+            },
+        })
+    }
+
+    /// Follows all aliases for a checker symbol in its owning project.
+    #[napi]
+    pub fn get_aliased_symbol(
+        &self,
+        snapshot: String,
+        project: String,
+        symbol: String,
+    ) -> Result<Value> {
+        let response = block_on(self.inner.get_aliased_symbol(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            SymbolHandle::from(symbol.as_str()),
+        ))
+        .map_err(into_napi_error)?;
+        to_value(&response)
+    }
+
+    #[napi]
+    pub fn get_aliased_symbol_async(
+        &self,
+        snapshot: String,
+        project: String,
+        symbol: String,
+    ) -> AsyncTask<JsonApiTask> {
+        AsyncTask::new(JsonApiTask {
+            client: self.inner.clone(),
+            kind: JsonTaskKind::GetAliasedSymbol {
+                snapshot,
+                project,
+                symbol,
+                immediate: false,
+            },
+        })
+    }
+
+    /// Follows one alias edge for a checker symbol in its owning project.
+    #[napi]
+    pub fn get_immediate_aliased_symbol(
+        &self,
+        snapshot: String,
+        project: String,
+        symbol: String,
+    ) -> Result<Value> {
+        let response = block_on(self.inner.get_immediate_aliased_symbol(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            SymbolHandle::from(symbol.as_str()),
+        ))
+        .map_err(into_napi_error)?;
+        to_value(&response)
+    }
+
+    #[napi]
+    pub fn get_immediate_aliased_symbol_async(
+        &self,
+        snapshot: String,
+        project: String,
+        symbol: String,
+    ) -> AsyncTask<JsonApiTask> {
+        AsyncTask::new(JsonApiTask {
+            client: self.inner.clone(),
+            kind: JsonTaskKind::GetAliasedSymbol {
+                snapshot,
+                project,
+                symbol,
+                immediate: true,
             },
         })
     }

--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -270,6 +270,9 @@ describe("CorsaApiClient", () => {
       expect(
         client.getImmediateAliasedSymbol(snapshot.snapshot, project.id, positionedSymbol!.id)?.name,
       ).toBe("value");
+      expect(
+        client.getExportsOfModule(snapshot.snapshot, project.id, positionedSymbol!.id),
+      ).toEqual([expect.objectContaining({ name: "value" })]);
       expect(client.getSymbolOfType(snapshot.snapshot, stringType.id, project.id)?.name).toBe(
         "value",
       );
@@ -366,6 +369,9 @@ describe("CorsaApiClient", () => {
       await expect(
         client.getImmediateAliasedSymbolAsync(snapshot.snapshot, project.id, positionedSymbol!.id),
       ).resolves.toEqual(expect.objectContaining({ name: "value" }));
+      await expect(
+        client.getExportsOfModuleAsync(snapshot.snapshot, project.id, positionedSymbol!.id),
+      ).resolves.toEqual([expect.objectContaining({ name: "value" })]);
       await expect(
         client.getSymbolOfTypeAsync(snapshot.snapshot, stringType.id, project.id),
       ).resolves.toEqual(expect.objectContaining({ name: "value" }));

--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -253,6 +253,23 @@ describe("CorsaApiClient", () => {
         client.getSymbolAtPosition(snapshot.snapshot, project.id, "/workspace/src/index.ts", 1)
           ?.name,
       ).toBe("value");
+      expect(
+        client
+          .getSymbolsAtPositions(snapshot.snapshot, project.id, "/workspace/src/index.ts", [1, 2])
+          .map((item) => item?.name),
+      ).toEqual(["value", undefined]);
+      const positionedSymbol = client.getSymbolAtPosition(
+        snapshot.snapshot,
+        project.id,
+        "/workspace/src/index.ts",
+        1,
+      );
+      expect(
+        client.getAliasedSymbol(snapshot.snapshot, project.id, positionedSymbol!.id)?.name,
+      ).toBe("value");
+      expect(
+        client.getImmediateAliasedSymbol(snapshot.snapshot, project.id, positionedSymbol!.id)?.name,
+      ).toBe("value");
       expect(client.getSymbolOfType(snapshot.snapshot, stringType.id, project.id)?.name).toBe(
         "value",
       );
@@ -329,6 +346,26 @@ describe("CorsaApiClient", () => {
         1,
       );
       expect(nodeType?.id).toBe("t0000000000000001");
+      await expect(
+        client.getSymbolsAtPositionsAsync(
+          snapshot.snapshot,
+          project.id,
+          "/workspace/src/index.ts",
+          [1, 2],
+        ),
+      ).resolves.toEqual([expect.objectContaining({ name: "value" }), null]);
+      const positionedSymbol = await client.getSymbolAtPositionAsync(
+        snapshot.snapshot,
+        project.id,
+        "/workspace/src/index.ts",
+        1,
+      );
+      await expect(
+        client.getAliasedSymbolAsync(snapshot.snapshot, project.id, positionedSymbol!.id),
+      ).resolves.toEqual(expect.objectContaining({ name: "value" }));
+      await expect(
+        client.getImmediateAliasedSymbolAsync(snapshot.snapshot, project.id, positionedSymbol!.id),
+      ).resolves.toEqual(expect.objectContaining({ name: "value" }));
       await expect(
         client.getSymbolOfTypeAsync(snapshot.snapshot, stringType.id, project.id),
       ).resolves.toEqual(expect.objectContaining({ name: "value" }));


### PR DESCRIPTION
## Summary

- expose sync and async N-API wrappers for project-scoped `getSymbolsAtPositions`
- expose sync and async wrappers for `getAliasedSymbol` and `getImmediateAliasedSymbol`
- document the hot-path batch API and alias precondition

The underlying checker endpoints already exist and are reachable through
`callJson`. This change makes common symbol-resolution paths discoverable in
the generated JavaScript API and avoids repeating untyped method and parameter
strings in consumers such as Uneffect.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p corsa_node --lib`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_node/ts/index.test.ts`
- `cargo check -p corsa_node`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added synchronous and asynchronous symbol lookup for multiple positions in a source file.
  * Added synchronous and asynchronous APIs for resolving aliased symbols, including immediate alias resolution.
  * Batch lookups resolve multiple positions in a single request.
* **Documentation**
  * Documented the new symbol-resolution and alias-resolution methods, including alias usage requirements.
* **Tests**
  * Added coverage for synchronous and asynchronous symbol and alias lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->