### PR TITLE
fix(napi): declare 1.13.0 symbol and alias methods in published types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ published versions.
 
 ### Fixed
 
+- published Node wrapper types now declare the 1.13.0 named methods `getSymbolsAtPositions`, `getAliasedSymbol`, `getImmediateAliasedSymbol`, and `getExportsOfModule`. The N-API binary already exposed them; `dist/index.d.mts` lagged because `ts/index.ts` was not updated.
 - the JSON driver mirrored numeric handles into `objectId` for only 26 of the 33 upstream methods that read it, so `getReturnTypeOfSignature`, `getApparentType`, `getApparentPropertiesOfType`, `getNonNullableType`, `getReducedType`, `getConstraintOfTypeParameter`, and `getDefaultFromTypeParameter` silently returned `null` on stable TypeScript 7 runtimes. `isTypeAssignableTo`'s `source`/`target` handles are now numeric-encoded as well.
 - `checker.getTypeAtLocation(callExpression)` resolved the touching token (the callee leaf) instead of the call result; call expressions now resolve through the callee's call signatures, `await` expressions unwrap the promise reference, and compound (`typeof A | typeof B`) constructor types keep their compound instance types through `new` expressions.
 - 33 of the 59 native rules were authored against a checker-fact vocabulary the JS bridge never produced, leaving whole rule paths silent in production (only synthetic-fact unit tests exercised them). Every rule's documented facts are now wired through per-rule fact providers, and all 59 rules carry `RuleTester` valid/invalid suites that run against the real pinned binary.

--- a/src/bindings/nodejs/corsa_node/ts/index.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.ts
@@ -79,6 +79,40 @@ export interface CorsaApiClient {
     file: string,
     position: number,
   ): Promise<SymbolResponse | null>;
+  getSymbolsAtPositions(
+    snapshot: string,
+    project: string,
+    file: string,
+    positions: number[],
+  ): Array<SymbolResponse | null>;
+  getSymbolsAtPositionsAsync(
+    snapshot: string,
+    project: string,
+    file: string,
+    positions: number[],
+  ): Promise<Array<SymbolResponse | null>>;
+  getAliasedSymbol(snapshot: string, project: string, symbol: string): SymbolResponse | null;
+  getAliasedSymbolAsync(
+    snapshot: string,
+    project: string,
+    symbol: string,
+  ): Promise<SymbolResponse | null>;
+  getImmediateAliasedSymbol(
+    snapshot: string,
+    project: string,
+    symbol: string,
+  ): SymbolResponse | null;
+  getImmediateAliasedSymbolAsync(
+    snapshot: string,
+    project: string,
+    symbol: string,
+  ): Promise<SymbolResponse | null>;
+  getExportsOfModule(snapshot: string, project: string, symbol: string): SymbolResponse[];
+  getExportsOfModuleAsync(
+    snapshot: string,
+    project: string,
+    symbol: string,
+  ): Promise<SymbolResponse[]>;
   getSymbolOfType(snapshot: string, typeHandle: string, project?: string): SymbolResponse | null;
   getSymbolOfTypeAsync(
     snapshot: string,


### PR DESCRIPTION
## Summary

- 1.13.0 already ships named N-API methods for `getSymbolsAtPositions`, `getAliasedSymbol`, `getImmediateAliasedSymbol`, and `getExportsOfModule` ([#475](https://github.com/ubugeeei-prod/corsa-bind/pull/475)).
- The handwritten wrapper interface in `ts/index.ts` was not updated, so packaged `dist/index.d.mts` omitted the names even though `index.d.ts` and the binary expose them.
- This change adds those methods to the published TypeScript facade. No runtime behavior change.

## Validation

- Existing mock-client tests already call the four methods.
- Type-only wrapper update; N-API binary unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791031557&installation_model_id=422833&pr_number=476&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F476&signature=9bc109ef942a10eec48564d8e2b14af5010ae88596ca455470ced930c01a0ade"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added synchronous and asynchronous APIs for querying symbols at multiple file positions.
  - Added APIs for retrieving aliased symbols, immediately aliased symbols, and module exports.

- **Bug Fixes**
  - Updated published Node.js type declarations to include the available symbol-query methods, ensuring TypeScript consumers receive accurate API typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->