### PR TITLE
feat(napi): expose batched getTypesAtPositions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ published versions.
 ### Added
 
 - the Node binding exposes named sync/async wrappers for project-scoped
+  `getTypesAtPositions`, so batched type lookups no longer need untyped
+  `callJson` strings. The handwritten wrapper interface is updated in the
+  same change so published `dist/index.d.mts` keeps the names.
   `getPropertyOfType` and `isTypeAssignableTo`. These are thin checker
   relations; `getSignaturesOfType` stays on `callJson` because that path
   fills `parameterTypeTexts`.

--- a/docs/nodejs_binding.md
+++ b/docs/nodejs_binding.md
@@ -160,6 +160,7 @@ All of these have `*Async` counterparts.
 | `getSourceFile(snapshot, project, file)`                    | `Buffer \| null`                               |
 | `getStringType(snapshot, project)`                          | `TypeResponse`                                 |
 | `getTypeAtPosition(snapshot, project, file, position)`      | `TypeResponse \| null`                         |
+| `getTypesAtPositions(snapshot, project, file, positions)`   | type response list                             |
 | `getSymbolAtPosition(snapshot, project, file, position)`    | symbol response                                |
 | `getSymbolsAtPositions(snapshot, project, file, positions)` | symbol response list                           |
 | `getAliasedSymbol(snapshot, project, symbol)`               | fully resolved symbol or unknown symbol        |
@@ -173,7 +174,8 @@ All of these have `*Async` counterparts.
 | `typeToString(snapshot, project, type)`                     | `string`                                       |
 
 The batch form performs one checker round trip for all positions in one source
-file. Alias methods require an alias symbol handle; check the returned symbol's
+file. `getTypesAtPositions` is the type-side counterpart of
+`getSymbolsAtPositions`. Alias methods require an alias symbol handle; check the returned symbol's
 flags before calling `getAliasedSymbol`, matching the upstream checker contract.
 Module exports likewise use the checker symbol handle rather than a source name.
 For endpoints without a typed wrapper, drop down to the raw calls below.

--- a/src/bindings/nodejs/corsa_node/index.d.ts
+++ b/src/bindings/nodejs/corsa_node/index.d.ts
@@ -28,6 +28,9 @@ export declare class CorsaApiClient {
   /** Resolves the checker type visible at a file position. */
   getTypeAtPosition(snapshot: string, project: string, file: string, position: number): any
   getTypeAtPositionAsync(snapshot: string, project: string, file: string, position: number): Promise<unknown>
+  /** Resolves checker types for source positions in one project-scoped request. */
+  getTypesAtPositions(snapshot: string, project: string, file: string, positions: Array<number>): any
+  getTypesAtPositionsAsync(snapshot: string, project: string, file: string, positions: Array<number>): Promise<unknown>
   /** Resolves the checker type for a source range using Rust-side lookup hints. */
   getTypeAtSourceRange(snapshot: string, project: string, file: string, start: number, end: number, sourceText: string, kind?: string | undefined | null): any
   getTypeAtSourceRangeAsync(snapshot: string, project: string, file: string, start: number, end: number, sourceText: string, kind?: string | undefined | null): Promise<unknown>

--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -181,6 +181,12 @@ enum JsonTaskKind {
         file: String,
         position: u32,
     },
+    GetTypesAtPositions {
+        snapshot: String,
+        project: String,
+        file: String,
+        positions: Vec<u32>,
+    },
     GetTypeAtSourceRange {
         snapshot: String,
         project: String,
@@ -329,6 +335,21 @@ impl<'task> ScopedTask<'task> for JsonApiTask {
                     ProjectHandle::from(project.as_str()),
                     file.clone(),
                     *position,
+                ))
+                .map_err(into_napi_error)?;
+                to_value(&response)
+            }
+            JsonTaskKind::GetTypesAtPositions {
+                snapshot,
+                project,
+                file,
+                positions,
+            } => {
+                let response = block_on(self.client.get_types_at_positions(
+                    SnapshotHandle::from(snapshot.as_str()),
+                    ProjectHandle::from(project.as_str()),
+                    file.clone(),
+                    positions.clone(),
                 ))
                 .map_err(into_napi_error)?;
                 to_value(&response)
@@ -872,6 +893,44 @@ impl CorsaApiClient {
                 project,
                 file,
                 position,
+            },
+        })
+    }
+
+    /// Resolves checker types for source positions in one project-scoped request.
+    #[napi]
+    pub fn get_types_at_positions(
+        &self,
+        snapshot: String,
+        project: String,
+        file: String,
+        positions: Vec<u32>,
+    ) -> Result<Value> {
+        let response = block_on(self.inner.get_types_at_positions(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            file,
+            positions,
+        ))
+        .map_err(into_napi_error)?;
+        to_value(&response)
+    }
+
+    #[napi]
+    pub fn get_types_at_positions_async(
+        &self,
+        snapshot: String,
+        project: String,
+        file: String,
+        positions: Vec<u32>,
+    ) -> AsyncTask<JsonApiTask> {
+        AsyncTask::new(JsonApiTask {
+            client: self.inner.clone(),
+            kind: JsonTaskKind::GetTypesAtPositions {
+                snapshot,
+                project,
+                file,
+                positions,
             },
         })
     }

--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -256,6 +256,11 @@ describe("CorsaApiClient", () => {
         client.isTypeAssignableTo(snapshot.snapshot, project.id, stringType.id, stringType.id),
       ).toBe(true);
       expect(
+        client
+          .getTypesAtPositions(snapshot.snapshot, project.id, "/workspace/src/index.ts", [1, 2])
+          .map((item) => item?.id),
+      ).toEqual(["t0000000000000001", "t0000000000000001"]);
+      expect(
         client.getSymbolAtPosition(snapshot.snapshot, project.id, "/workspace/src/index.ts", 1)
           ?.name,
       ).toBe("value");
@@ -356,11 +361,24 @@ describe("CorsaApiClient", () => {
       );
       expect(nodeType?.id).toBe("t0000000000000001");
       await expect(
+<<<<<<< HEAD
         client.getPropertyOfTypeAsync(snapshot.snapshot, project.id, stringType.id, "length"),
       ).resolves.toEqual(expect.objectContaining({ name: "value" }));
       await expect(
         client.isTypeAssignableToAsync(snapshot.snapshot, project.id, stringType.id, stringType.id),
       ).resolves.toBe(true);
+=======
+        client.getTypesAtPositionsAsync(
+          snapshot.snapshot,
+          project.id,
+          "/workspace/src/index.ts",
+          [1, 2],
+        ),
+      ).resolves.toEqual([
+        expect.objectContaining({ id: "t0000000000000001" }),
+        expect.objectContaining({ id: "t0000000000000001" }),
+      ]);
+>>>>>>> 5aa936a (feat(napi): expose batched getTypesAtPositions)
       await expect(
         client.getSymbolsAtPositionsAsync(
           snapshot.snapshot,

--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -361,13 +361,12 @@ describe("CorsaApiClient", () => {
       );
       expect(nodeType?.id).toBe("t0000000000000001");
       await expect(
-<<<<<<< HEAD
         client.getPropertyOfTypeAsync(snapshot.snapshot, project.id, stringType.id, "length"),
       ).resolves.toEqual(expect.objectContaining({ name: "value" }));
       await expect(
         client.isTypeAssignableToAsync(snapshot.snapshot, project.id, stringType.id, stringType.id),
       ).resolves.toBe(true);
-=======
+      await expect(
         client.getTypesAtPositionsAsync(
           snapshot.snapshot,
           project.id,
@@ -378,7 +377,6 @@ describe("CorsaApiClient", () => {
         expect.objectContaining({ id: "t0000000000000001" }),
         expect.objectContaining({ id: "t0000000000000001" }),
       ]);
->>>>>>> 5aa936a (feat(napi): expose batched getTypesAtPositions)
       await expect(
         client.getSymbolsAtPositionsAsync(
           snapshot.snapshot,

--- a/src/bindings/nodejs/corsa_node/ts/index.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.ts
@@ -49,6 +49,18 @@ export interface CorsaApiClient {
     file: string,
     position: number,
   ): Promise<TypeResponse | null>;
+  getTypesAtPositions(
+    snapshot: string,
+    project: string,
+    file: string,
+    positions: number[],
+  ): Array<TypeResponse | null>;
+  getTypesAtPositionsAsync(
+    snapshot: string,
+    project: string,
+    file: string,
+    positions: number[],
+  ): Promise<Array<TypeResponse | null>>;
   getTypeAtSourceRange(
     snapshot: string,
     project: string,


### PR DESCRIPTION
## Summary

- expose sync and async N-API wrappers for project-scoped `getTypesAtPositions`
- update the handwritten `ts/index.ts` facade in the same change so packaged `dist/index.d.mts` keeps the name
- document the type-side batch counterpart of `getSymbolsAtPositions`

The underlying checker endpoint already exists and is reachable through `callJson`. This change makes the hot-path batch type lookup discoverable in the generated JavaScript API and avoids repeating untyped method and parameter strings in consumers such as Uneffect.

This is separate from [#475](https://github.com/ubugeeei-prod/corsa-bind/pull/475) (batched symbols / alias / exports) and [#476](https://github.com/ubugeeei-prod/corsa-bind/pull/476) (published types for those 1.13.0 methods).

## Validation

- `cargo fmt -p corsa_node -- --check`
- `cargo check -p corsa_node`
- `cargo test -p corsa_node --lib`
- `napi build --platform`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_node/ts/index.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791032424&installation_model_id=422833&pr_number=477&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F477&signature=0882aab125f5a507a0445399d43fb50f8b34c3306387e946f7ea7ce548be5fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added synchronous and asynchronous Node.js APIs for retrieving type information at multiple source positions in a single request.
  - Batched lookups return type results for each requested position, reducing the need for repeated individual queries.

- **Documentation**
  - Updated the Node.js binding reference with the new batched type lookup methods and usage context.

- **Tests**
  - Added coverage for synchronous and asynchronous batched type lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->