### PR TITLE
feat(napi): expose getPropertyOfType and isTypeAssignableTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ published versions.
 ### Added
 
 - the Node binding exposes named sync/async wrappers for project-scoped
+  `getPropertyOfType` and `isTypeAssignableTo`. These are thin checker
+  relations; `getSignaturesOfType` stays on `callJson` because that path
+  fills `parameterTypeTexts`.
+- the Node binding exposes named sync/async wrappers for project-scoped
   `getSymbolsAtPositions`, `getAliasedSymbol`, and
   `getImmediateAliasedSymbol`, avoiding untyped `callJson` calls on common
   symbol-resolution hot paths. The same facade now exposes

--- a/docs/nodejs_binding.md
+++ b/docs/nodejs_binding.md
@@ -165,6 +165,8 @@ All of these have `*Async` counterparts.
 | `getAliasedSymbol(snapshot, project, symbol)`               | fully resolved symbol or unknown symbol        |
 | `getImmediateAliasedSymbol(snapshot, project, symbol)`      | next alias target or `null`                    |
 | `getExportsOfModule(snapshot, project, symbol)`             | checker-owned module exports                   |
+| `getPropertyOfType(snapshot, project, type, name)`          | symbol response or `null`                      |
+| `isTypeAssignableTo(snapshot, project, source, target)`     | `boolean`                                      |
 | `getTypeArguments(snapshot, project, type)`                 | type list                                      |
 | `getTypeOfSymbol(snapshot, project, symbol)`                | `TypeResponse \| null`                         |
 | `getDeclaredTypeOfSymbol(snapshot, project, symbol)`        | `TypeResponse \| null`                         |

--- a/src/bindings/nodejs/corsa_node/index.d.ts
+++ b/src/bindings/nodejs/corsa_node/index.d.ts
@@ -60,6 +60,12 @@ export declare class CorsaApiClient {
   getTypeArgumentsAtSourceRange(snapshot: string, project: string, typeHandle: string, objectFlags: number | undefined | null, file: string, start: number, end: number, sourceText: string): any
   getTypeArgumentsAsync(snapshot: string, project: string, typeHandle: string, objectFlags?: number | undefined | null): Promise<unknown>
   getTypeArgumentsAtSourceRangeAsync(snapshot: string, project: string, typeHandle: string, objectFlags: number | undefined | null, file: string, start: number, end: number, sourceText: string): Promise<unknown>
+  /** Resolves a named property on a checker type in its owning project. */
+  getPropertyOfType(snapshot: string, project: string, typeHandle: string, name: string): any
+  getPropertyOfTypeAsync(snapshot: string, project: string, typeHandle: string, name: string): Promise<unknown>
+  /** Returns whether `source` is assignable to `target` in the owning project. */
+  isTypeAssignableTo(snapshot: string, project: string, source: string, target: string): any
+  isTypeAssignableToAsync(snapshot: string, project: string, source: string, target: string): Promise<unknown>
   /** Resolves a type constraint using Corsa relation endpoints. */
   getConstraintOfType(snapshot: string, project: string, typeHandle: string): any
   getConstraintOfTypeAsync(snapshot: string, project: string, typeHandle: string): Promise<unknown>

--- a/src/bindings/nodejs/corsa_node/src/api_client.rs
+++ b/src/bindings/nodejs/corsa_node/src/api_client.rs
@@ -249,6 +249,18 @@ enum JsonTaskKind {
         project: String,
         type_handle: String,
     },
+    GetPropertyOfType {
+        snapshot: String,
+        project: String,
+        type_handle: String,
+        name: String,
+    },
+    IsTypeAssignableTo {
+        snapshot: String,
+        project: String,
+        source: String,
+        target: String,
+    },
     TypeToString {
         snapshot: String,
         project: String,
@@ -491,6 +503,36 @@ impl<'task> ScopedTask<'task> for JsonApiTask {
                     SnapshotHandle::from(snapshot.as_str()),
                     ProjectHandle::from(project.as_str()),
                     SymbolHandle::from(symbol.as_str()),
+                ))
+                .map_err(into_napi_error)?;
+                to_value(&response)
+            }
+            JsonTaskKind::GetPropertyOfType {
+                snapshot,
+                project,
+                type_handle,
+                name,
+            } => {
+                let response = block_on(self.client.get_property_of_type(
+                    SnapshotHandle::from(snapshot.as_str()),
+                    ProjectHandle::from(project.as_str()),
+                    TypeHandle::from(type_handle.as_str()),
+                    name.clone(),
+                ))
+                .map_err(into_napi_error)?;
+                to_value(&response)
+            }
+            JsonTaskKind::IsTypeAssignableTo {
+                snapshot,
+                project,
+                source,
+                target,
+            } => {
+                let response = block_on(self.client.is_type_assignable_to(
+                    SnapshotHandle::from(snapshot.as_str()),
+                    ProjectHandle::from(project.as_str()),
+                    TypeHandle::from(source.as_str()),
+                    TypeHandle::from(target.as_str()),
                 ))
                 .map_err(into_napi_error)?;
                 to_value(&response)
@@ -1202,6 +1244,82 @@ impl CorsaApiClient {
                 start,
                 end,
                 source_text,
+            },
+        })
+    }
+
+    /// Resolves a named property on a checker type in its owning project.
+    #[napi]
+    pub fn get_property_of_type(
+        &self,
+        snapshot: String,
+        project: String,
+        type_handle: String,
+        name: String,
+    ) -> Result<Value> {
+        let response = block_on(self.inner.get_property_of_type(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            TypeHandle::from(type_handle.as_str()),
+            name,
+        ))
+        .map_err(into_napi_error)?;
+        to_value(&response)
+    }
+
+    #[napi]
+    pub fn get_property_of_type_async(
+        &self,
+        snapshot: String,
+        project: String,
+        type_handle: String,
+        name: String,
+    ) -> AsyncTask<JsonApiTask> {
+        AsyncTask::new(JsonApiTask {
+            client: self.inner.clone(),
+            kind: JsonTaskKind::GetPropertyOfType {
+                snapshot,
+                project,
+                type_handle,
+                name,
+            },
+        })
+    }
+
+    /// Returns whether `source` is assignable to `target` in the owning project.
+    #[napi]
+    pub fn is_type_assignable_to(
+        &self,
+        snapshot: String,
+        project: String,
+        source: String,
+        target: String,
+    ) -> Result<Value> {
+        let response = block_on(self.inner.is_type_assignable_to(
+            SnapshotHandle::from(snapshot.as_str()),
+            ProjectHandle::from(project.as_str()),
+            TypeHandle::from(source.as_str()),
+            TypeHandle::from(target.as_str()),
+        ))
+        .map_err(into_napi_error)?;
+        to_value(&response)
+    }
+
+    #[napi]
+    pub fn is_type_assignable_to_async(
+        &self,
+        snapshot: String,
+        project: String,
+        source: String,
+        target: String,
+    ) -> AsyncTask<JsonApiTask> {
+        AsyncTask::new(JsonApiTask {
+            client: self.inner.clone(),
+            kind: JsonTaskKind::IsTypeAssignableTo {
+                snapshot,
+                project,
+                source,
+                target,
             },
         })
     }

--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -250,6 +250,12 @@ describe("CorsaApiClient", () => {
         client.getTypeAtPosition(snapshot.snapshot, project.id, "/workspace/src/index.ts", 1)?.id,
       ).toBe("t0000000000000001");
       expect(
+        client.getPropertyOfType(snapshot.snapshot, project.id, stringType.id, "length")?.name,
+      ).toBe("value");
+      expect(
+        client.isTypeAssignableTo(snapshot.snapshot, project.id, stringType.id, stringType.id),
+      ).toBe(true);
+      expect(
         client.getSymbolAtPosition(snapshot.snapshot, project.id, "/workspace/src/index.ts", 1)
           ?.name,
       ).toBe("value");
@@ -349,6 +355,12 @@ describe("CorsaApiClient", () => {
         1,
       );
       expect(nodeType?.id).toBe("t0000000000000001");
+      await expect(
+        client.getPropertyOfTypeAsync(snapshot.snapshot, project.id, stringType.id, "length"),
+      ).resolves.toEqual(expect.objectContaining({ name: "value" }));
+      await expect(
+        client.isTypeAssignableToAsync(snapshot.snapshot, project.id, stringType.id, stringType.id),
+      ).resolves.toBe(true);
       await expect(
         client.getSymbolsAtPositionsAsync(
           snapshot.snapshot,

--- a/src/bindings/nodejs/corsa_node/ts/index.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.ts
@@ -117,6 +117,30 @@ export interface CorsaApiClient {
     end: number,
     sourceText: string,
   ): Promise<TypeResponse[]>;
+  getPropertyOfType(
+    snapshot: string,
+    project: string,
+    typeHandle: string,
+    name: string,
+  ): SymbolResponse | null;
+  getPropertyOfTypeAsync(
+    snapshot: string,
+    project: string,
+    typeHandle: string,
+    name: string,
+  ): Promise<SymbolResponse | null>;
+  isTypeAssignableTo(
+    snapshot: string,
+    project: string,
+    source: string,
+    target: string,
+  ): boolean;
+  isTypeAssignableToAsync(
+    snapshot: string,
+    project: string,
+    source: string,
+    target: string,
+  ): Promise<boolean>;
   getConstraintOfType(snapshot: string, project: string, typeHandle: string): TypeResponse | null;
   getConstraintOfTypeAsync(
     snapshot: string,

--- a/src/bindings/nodejs/corsa_node/ts/index.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.ts
@@ -129,12 +129,7 @@ export interface CorsaApiClient {
     typeHandle: string,
     name: string,
   ): Promise<SymbolResponse | null>;
-  isTypeAssignableTo(
-    snapshot: string,
-    project: string,
-    source: string,
-    target: string,
-  ): boolean;
+  isTypeAssignableTo(snapshot: string, project: string, source: string, target: string): boolean;
   isTypeAssignableToAsync(
     snapshot: string,
     project: string,


### PR DESCRIPTION
## Summary

- expose sync and async N-API wrappers for project-scoped `getPropertyOfType` and `isTypeAssignableTo`
- update the handwritten `ts/index.ts` facade in the same change
- leave `getSignaturesOfType` on `callJson`; that path fills `parameterTypeTexts` / parameter symbols and a thin `ApiClient::get_signatures_of_type` wrapper would drop them

The underlying checker endpoints already exist. This is separate from [#475](https://github.com/ubugeeei-prod/corsa-bind/pull/475) (symbols/alias), [#476](https://github.com/ubugeeei-prod/corsa-bind/pull/476) (published types), and [#477](https://github.com/ubugeeei-prod/corsa-bind/pull/477) (batched types).

## Validation

- `cargo fmt -p corsa_node -- --check`
- `cargo check -p corsa_node`
- `cargo test -p corsa_node --lib`
- `napi build --platform`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_node/ts/index.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791033371&installation_model_id=422833&pr_number=478&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F478&signature=0e6960bac1ced064c6f4f89a88b4bdfe54093845c244ccae1fa411b719f5cc81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->