### PR TITLE
fix(oxlint): resolve compound type locations

### DIFF
--- a/corsa_ref.lock.toml
+++ b/corsa_ref.lock.toml
@@ -3,8 +3,8 @@ version = 1
 [corsa_upstream]
 path = "ref/corsa-upstream"
 repository = "https://github.com/microsoft/TypeScript.git"
-commit = "0c8f63f745ec8c8243c7d43d13e3f2fe8e04bc53"
-tree = "5454a5e45644ae655ae1bfd95cc92578a77ed35e"
-committer_date = "2026-08-25T17:32:50+00:00"
-author = "Rafli Surya Wijaya"
-subject = "docs(readme): update blog link to devblogs and use relative CONTRIBUTING.md links (#63994)"
+commit = "e73c923cb58e9ea8cd75ba41c51b8d8886af3076"
+tree = "4a3b3b3f2c23d4d732d5ab0bcf9cf966643148ad"
+committer_date = "2026-09-03T21:38:15Z"
+author = "Matheus Mol"
+subject = "API: add getChildren and token getters to Node (#63893)"

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -83,6 +83,24 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
           return resolved;
         }
       }
+      if (kind === "MemberExpression") {
+        const resolved = typeOfComputedMemberExpression(context, node as Node, this);
+        if (resolved) {
+          return resolved;
+        }
+      }
+      if (kind === "ConditionalExpression") {
+        const resolved = typeOfConditionalExpression(node as Node, this);
+        if (resolved) {
+          return resolved;
+        }
+      }
+      if (typeNodeNeedsDeclarationLookup(node as Node)) {
+        const resolved = typeOfEnclosingDeclarationAnnotation(node as Node, this);
+        if (resolved) {
+          return resolved;
+        }
+      }
       const lookupNode = nodeForTypeLookup(node);
       const type = sessionForContext(context).session.getTypeAtSourceRange(
         filenameFor(context, lookupNode),
@@ -542,6 +560,156 @@ function typeOfAwaitExpression(
   const awaited = checker.getTypeArguments(argumentType)[0] ?? argumentType;
   sessionForContext(context).session.rememberTypeLookupFromType(awaited, argumentType);
   return awaited;
+}
+
+function typeOfComputedMemberExpression(
+  context: ContextWithParserOptions,
+  node: Node,
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined {
+  if ((node as unknown as { readonly computed?: boolean }).computed !== true) {
+    return undefined;
+  }
+  const object = childNode(node, "object");
+  const property = childNode(node, "property");
+  if (!object || !property) {
+    return undefined;
+  }
+  const objectType = checker.getTypeAtLocation(object);
+  if (!objectType) {
+    return undefined;
+  }
+  const propertyName = computedPropertyName(property);
+  const propertyType = propertyName
+    ? typeOfNamedProperty(objectType, propertyName, checker)
+    : undefined;
+  const indexedType = propertyType ?? typeOfIndexedMember(objectType, property, checker);
+  if (indexedType) {
+    sessionForContext(context).session.rememberTypeLookupFromType(indexedType, objectType);
+  }
+  return indexedType;
+}
+
+function typeOfNamedProperty(
+  objectType: CorsaType,
+  propertyName: string,
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined {
+  const symbol = checker
+    .getPropertiesOfType(objectType)
+    .find((property) => property.name === propertyName);
+  return symbol
+    ? (checker.getTypeOfSymbol(symbol) ?? checker.getDeclaredTypeOfSymbol(symbol))
+    : undefined;
+}
+
+function typeOfIndexedMember(
+  objectType: CorsaType,
+  property: Node,
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined {
+  const typeArguments = checker.getTypeArguments(objectType);
+  if (typeArguments.length === 0) {
+    return undefined;
+  }
+  const text = safeTypeToString(checker, objectType) ?? objectType.texts?.[0] ?? "";
+  const index = numericLiteralValue(property);
+  if (index !== undefined && tupleLikeTypeText(text)) {
+    return typeArguments[index];
+  }
+  if (index !== undefined && arrayLikeTypeText(text)) {
+    return typeArguments[0];
+  }
+  if (computedPropertyName(property) !== undefined && recordLikeTypeText(text)) {
+    return typeArguments[1];
+  }
+  return undefined;
+}
+
+function typeOfConditionalExpression(
+  node: Node,
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined {
+  const consequent = childNode(node, "consequent");
+  const alternate = childNode(node, "alternate");
+  if (!consequent || !alternate) {
+    return undefined;
+  }
+  const consequentType = checker.getTypeAtLocation(consequent);
+  const alternateType = checker.getTypeAtLocation(alternate);
+  return syntheticCompoundType(
+    "union",
+    [consequentType, alternateType].filter((type): type is CorsaType => type !== undefined),
+    checker,
+  );
+}
+
+function typeOfEnclosingDeclarationAnnotation(
+  node: Node,
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined {
+  const declaration = enclosingTypedPropertyDeclaration(node);
+  return declaration ? checker.getTypeAtLocation(declaration) : undefined;
+}
+
+function typeNodeNeedsDeclarationLookup(node: Node): boolean {
+  switch ((node as { readonly type?: string }).type) {
+    case "TSArrayType":
+    case "TSTupleType":
+    case "TSUnionType":
+    case "TSIntersectionType":
+      return enclosingTypedPropertyDeclaration(node) !== undefined;
+    case "TSTypeReference":
+      return (
+        typeArgumentNodes(node as unknown as Record<string, unknown>).length > 0 &&
+        enclosingTypedPropertyDeclaration(node) !== undefined
+      );
+    default:
+      return false;
+  }
+}
+
+function enclosingTypedPropertyDeclaration(node: Node): Node | undefined {
+  const annotation = parentNode(node);
+  if (!annotation || (annotation as { readonly type?: string }).type !== "TSTypeAnnotation") {
+    return undefined;
+  }
+  const declaration = parentNode(annotation);
+  switch ((declaration as { readonly type?: string } | undefined)?.type) {
+    case "PropertyDefinition":
+    case "TSAbstractPropertyDefinition":
+    case "TSPropertySignature":
+      return declaration;
+    default:
+      return undefined;
+  }
+}
+
+function computedPropertyName(node: Node): string | undefined {
+  const value = (node as unknown as { readonly value?: unknown }).value;
+  return typeof value === "string" || typeof value === "number" ? String(value) : undefined;
+}
+
+function numericLiteralValue(node: Node): number | undefined {
+  const value = (node as unknown as { readonly value?: unknown }).value;
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : undefined;
+}
+
+function tupleLikeTypeText(text: string): boolean {
+  return text.startsWith("[") || text.startsWith("readonly [");
+}
+
+function arrayLikeTypeText(text: string): boolean {
+  return (
+    text.endsWith("[]") ||
+    text.startsWith("Array<") ||
+    text.startsWith("ReadonlyArray<") ||
+    text.startsWith("readonly ")
+  );
+}
+
+function recordLikeTypeText(text: string): boolean {
+  return text.startsWith("Record<");
 }
 
 function typeOfNewExpression(
@@ -1197,7 +1365,7 @@ function nodeForTypeLookup(node: Node | CorsaNode): Node | CorsaNode {
       return childNode(node, "key") ?? node;
     case "PropertyDefinition":
     case "TSAbstractPropertyDefinition":
-      return childNode(node, "typeAnnotation") ?? childNode(node, "key") ?? node;
+      return childNode(node, "key") ?? childNode(node, "typeAnnotation") ?? node;
     default:
       return node;
   }
@@ -1243,6 +1411,10 @@ function implementedClauseChildNode(node: Node, key: string): Node | undefined {
     return value;
   }
   return undefined;
+}
+
+function parentNode(node: Node): Node | undefined {
+  return childNode(node, "parent");
 }
 
 function implementedTypesFromCorsaNode(

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -90,10 +90,7 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
         }
       }
       if (kind === "ConditionalExpression") {
-        const resolved = typeOfConditionalExpression(node as Node, this);
-        if (resolved) {
-          return resolved;
-        }
+        return typeOfConditionalExpression(node as Node, this);
       }
       if (typeNodeNeedsDeclarationLookup(node as Node)) {
         const resolved = typeOfEnclosingDeclarationAnnotation(node as Node, this);
@@ -637,11 +634,10 @@ function typeOfConditionalExpression(
   }
   const consequentType = checker.getTypeAtLocation(consequent);
   const alternateType = checker.getTypeAtLocation(alternate);
-  return syntheticCompoundType(
-    "union",
-    [consequentType, alternateType].filter((type): type is CorsaType => type !== undefined),
-    checker,
-  );
+  if (!consequentType || !alternateType) {
+    return undefined;
+  }
+  return syntheticCompoundType("union", [consequentType, alternateType], checker);
 }
 
 function typeOfEnclosingDeclarationAnnotation(

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker_conditional.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker_conditional.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CorsaType } from "./types";
+
+const mocks = vi.hoisted(() => {
+  const knownType = {
+    __corsaOxlintKind: "type",
+    id: "known-type",
+    flags: 0,
+    texts: ["Known"],
+  } as CorsaType;
+  const fallbackType = {
+    __corsaOxlintKind: "type",
+    id: "fallback-type",
+    flags: 0,
+    texts: ["boolean"],
+  } as CorsaType;
+  return {
+    session: {
+      getTypeAtSourceRange: vi.fn(
+        (
+          _fileName: string,
+          position: number,
+          _end: number,
+          _sourceText: string | undefined,
+          nodeKind: string | undefined,
+        ) => {
+          if (nodeKind === "ConditionalExpression") {
+            return fallbackType;
+          }
+          return position === 7 ? knownType : undefined;
+        },
+      ),
+    },
+  };
+});
+
+vi.mock("./registry", () => ({
+  sessionForContext: vi.fn(() => ({
+    project: { rootDir: "/workspace" },
+    session: mocks.session,
+  })),
+}));
+
+const { createTypeChecker } = await import("./checker");
+
+describe("createTypeChecker conditional type locations", () => {
+  beforeEach(() => {
+    mocks.session.getTypeAtSourceRange.mockClear();
+  });
+
+  it("does not collapse a conditional expression when either branch is unresolved", () => {
+    const sourceText = "flag ? known : missing";
+    const checker = createTypeChecker({
+      cwd: "/workspace",
+      filename: "/workspace/src/index.ts",
+      sourceCode: { text: sourceText },
+      settings: {},
+    } as never);
+
+    const type = checker.getTypeAtLocation({
+      type: "ConditionalExpression",
+      range: [0, sourceText.length],
+      test: { type: "Identifier", name: "flag", range: [0, 4] },
+      consequent: { type: "Identifier", name: "known", range: [7, 12] },
+      alternate: { type: "Identifier", name: "missing", range: [15, 22] },
+    } as never);
+
+    expect(type).toBeUndefined();
+    expect(mocks.session.getTypeAtSourceRange).toHaveBeenCalledTimes(2);
+    expect(mocks.session.getTypeAtSourceRange.mock.calls.map((call) => call[4])).toEqual([
+      "Identifier",
+      "Identifier",
+    ]);
+  });
+});

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -670,6 +670,252 @@ describe("corsa oxlint type locations", () => {
     expect(seen.number).toBe("number");
   });
 
+  integrationCase("resolves compound expression nodes to their own types", () => {
+    const seen: Record<string, string | undefined> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "compound-expression-node-types",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise compound expression type lookup",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          CallExpression(node: any) {
+            if (node.callee?.type !== "Identifier" || node.callee.name !== "probe") {
+              return;
+            }
+            const argument = node.arguments?.[0];
+            if (!argument) {
+              return;
+            }
+            const type = services.getTypeAtLocation(argument);
+            seen[context.sourceCode.getText(argument)] = type
+              ? checker.typeToString(type)
+              : undefined;
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester({ languageOptions: { sourceType: "module" } });
+    tester.run("compound-expression-node-types", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Target { marker = 1; }",
+            "class Holder {",
+            "  plain: Target = new Target();",
+            "  method(): Target { return new Target(); }",
+            "}",
+            "function make(): Target { return new Target(); }",
+            "function probe(_value: unknown): void {}",
+            "const holder = new Holder();",
+            "const targets = [new Target()];",
+            "const keyed: Record<string, Target> = { value: new Target() };",
+            "const flag = Math.random() > 0.5;",
+            "const pending = Promise.resolve(new Target());",
+            "async function main(): Promise<void> {",
+            "  probe(holder);",
+            "  probe(holder.plain);",
+            "  probe(holder.method());",
+            "  probe(make());",
+            "  probe(targets[0]);",
+            '  probe(keyed["value"]);',
+            "  probe(flag ? holder.plain : make());",
+            "  probe(await pending);",
+            "}",
+            "void main;",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                  mode: "jsonrpc",
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen).toEqual({
+      holder: "Holder",
+      "holder.plain": "Target",
+      "holder.method()": "Target",
+      "make()": "Target",
+      "targets[0]": "Target",
+      'keyed["value"]': "Target",
+      "flag ? holder.plain : make()": "Target",
+      "await pending": "Target",
+    });
+  });
+
+  integrationCase("resolves modified property definition nodes to their declared types", () => {
+    const seen: Record<string, { readonly node?: string; readonly key?: string }> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "modified-property-definition-node-types",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise property definition type lookup with modifiers",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          PropertyDefinition(node: any) {
+            const name = node.key?.name;
+            if (!name) {
+              return;
+            }
+            const nodeType = services.getTypeAtLocation(node);
+            const keyType = services.getTypeAtLocation(node.key);
+            seen[name] = {
+              node: nodeType ? checker.typeToString(nodeType) : undefined,
+              key: keyType ? checker.typeToString(keyType) : undefined,
+            };
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester({ languageOptions: { sourceType: "module" } });
+    tester.run("modified-property-definition-node-types", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Target {}",
+            "class Holder {",
+            "  plain: Target = new Target();",
+            "  definite!: Target;",
+            "  optional?: Target;",
+            "}",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                  mode: "jsonrpc",
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen).toEqual({
+      plain: { node: "Target", key: "Target" },
+      definite: { node: "Target", key: "Target" },
+      optional: { node: "Target | undefined", key: "Target | undefined" },
+    });
+  });
+
+  integrationCase("resolves composite type annotation nodes to instantiated types", () => {
+    const seen: Record<string, { readonly annotation?: string; readonly property?: string }> = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "composite-type-annotation-node-types",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise composite type annotation lookup",
+          requiresTypeChecking: true,
+        },
+        messages: {
+          unexpected: "unexpected",
+        },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        return {
+          PropertyDefinition(node: any) {
+            const name = node.key?.name;
+            const annotation = node.typeAnnotation?.typeAnnotation;
+            if (!name || !annotation) {
+              return;
+            }
+            const annotationType = services.getTypeAtLocation(annotation);
+            const propertyType = services.getTypeAtLocation(node);
+            seen[name] = {
+              annotation: annotationType ? checker.typeToString(annotationType) : undefined,
+              property: propertyType ? checker.typeToString(propertyType) : undefined,
+            };
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester({ languageOptions: { sourceType: "module" } });
+    tester.run("composite-type-annotation-node-types", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Target { marker = 1; }",
+            "class Holder {",
+            "  plain: Target = new Target();",
+            "  list: Target[] = [];",
+            "  pair: [Target, Target] = [new Target(), new Target()];",
+            "  union: Target | undefined = undefined;",
+            '  intersection: Target & { extra: string } = Object.assign(new Target(), { extra: "" });',
+            "  wrapped: Readonly<Target> = new Target();",
+            "}",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                  mode: "jsonrpc",
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen).toEqual({
+      plain: { annotation: "Target", property: "Target" },
+      list: { annotation: "Target[]", property: "Target[]" },
+      pair: { annotation: "[Target, Target]", property: "[Target, Target]" },
+      union: { annotation: "Target | undefined", property: "Target | undefined" },
+      intersection: {
+        annotation: "Target & { extra: string; }",
+        property: "Target & { extra: string; }",
+      },
+      wrapped: { annotation: "Readonly<Target>", property: "Readonly<Target>" },
+    });
+  });
+
   integrationCase("falls back for instantiated generic base types", () => {
     const seen: Record<string, readonly string[] | undefined> = {};
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);

--- a/src/bindings/rust/corsa/tests/data/real_corsa_api_baseline.json
+++ b/src/bindings/rust/corsa/tests/data/real_corsa_api_baseline.json
@@ -1,12 +1,12 @@
 {
   "currentDirectory": ".",
-  "fileCount": 106,
-  "firstFile": "ref/corsa-upstream/packages/typescript/src/api/fs.ts",
+  "fileCount": 108,
+  "firstFile": "ref/corsa-upstream/packages/typescript/src/api/diagnosticFormatter.ts",
   "lastFile": "ref/corsa-upstream/packages/typescript/src/internal/utils.ts",
   "projectCount": 1,
-  "rootFiles": 106,
+  "rootFiles": 108,
   "configFileName": "ref/corsa-upstream/packages/typescript/tsconfig.json",
-  "primaryFile": "ref/corsa-upstream/packages/typescript/src/api/fs.ts",
+  "primaryFile": "ref/corsa-upstream/packages/typescript/src/api/diagnosticFormatter.ts",
   "stringTypeFlags": 32,
   "rendered": "string"
 }


### PR DESCRIPTION
## Summary
- resolve `getTypeAtLocation` for computed member and conditional expression nodes
- resolve definite/optional property declarations and composite annotation type nodes from their enclosing declaration
- add integration regressions for the three open `getTypeAtLocation` bugs
- update the TypeScript upstream pin to `e73c923cb58e9ea8cd75ba41c51b8d8886af3076` and refresh the real Corsa API baseline

Fixes #472
Fixes #473
Fixes #474

## Validation
- `vp fmt --check`
- `vp check`
- `CI=true GOTOOLCHAIN=auto vp run -w build_corsa`
- `CI=true GOTOOLCHAIN=auto CORSA_REQUIRE_INTEGRATION=1 vp run -w test_ts`
- `CI=true GOTOOLCHAIN=auto cargo test --workspace --quiet`
- `CI=true GOTOOLCHAIN=auto cargo test -p corsa --no-default-features --test real_corsa_regression --test real_corsa_typecheck --test real_corsa_baseline`
- `CI=true GOTOOLCHAIN=auto vp run -w release_dry_run`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791086459&installation_model_id=422833&pr_number=479&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F479&signature=93284b9a35d23395046b983913a93bc4fcf5953f128d755f85fcd1fc8a23b843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TypeScript type resolution for complex expressions, including conditional expressions, computed properties, array and tuple access, unions, intersections, mapped types, and generic types.
  - Improved type detection for optional and definite properties, function calls, member access, and asynchronous expressions.
  - Corrected type resolution for modified property definitions and composite type annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->