### PR TITLE
feat(napi): add checker query batching helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ published versions.
 
 ### Added
 
+- the Node binding adds `batchCheckerRequests` / `batchCheckerRequestsAsync`
+  for upstream `batchRequests` and `resolveCheckerBatch` /
+  `resolveCheckerBatchAsync` for project-scoped checker hot paths. The higher
+  layer coalesces repeated position queries, batches symbol-to-type fan-out via
+  `getTypesOfSymbols`, and keeps follow-up relation primitives such as
+  `getPropertyOfType`, `getTypeArguments`, `getConstraintOfType`, and
+  `isTypeAssignableTo` in one transport round trip.
 - the Node binding exposes named sync/async wrappers for project-scoped
   `getTypesAtPositions`, so batched type lookups no longer need untyped
   `callJson` strings. The handwritten wrapper interface is updated in the

--- a/docs/nodejs_binding.md
+++ b/docs/nodejs_binding.md
@@ -180,6 +180,26 @@ flags before calling `getAliasedSymbol`, matching the upstream checker contract.
 Module exports likewise use the checker symbol handle rather than a source name.
 For endpoints without a typed wrapper, drop down to the raw calls below.
 
+For N+1-prone checker workflows, keep these primitives but run them through the
+batch helpers:
+
+```ts
+import { resolveCheckerBatch } from "@corsa-bind/napi";
+
+const facts = resolveCheckerBatch(client, { snapshot, project: project.id }, [
+  { key: "nodes", kind: "typesAtPositions", file, positions: nodeStarts },
+  { key: "value", kind: "propertyOfType", type: valueType.id, name: "value" },
+  { key: "assignable", kind: "isTypeAssignableTo", source: valueType.id, target: targetType.id },
+]);
+```
+
+`resolveCheckerBatch` coalesces repeated positions per file, uses
+`getTypesOfSymbols` for symbol-type fan-out, and sends the remaining relation
+queries (`propertyOfType`, `typeArguments`, `constraintOfType`, alias
+resolution, assignability, and similar follow-ups) through upstream
+`batchRequests`. Use `batchCheckerRequests` when you need the lower-level raw
+batch primitive directly.
+
 ## Raw calls (escape hatch)
 
 When you need an endpoint that does not have a dedicated method, call it

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -26,6 +26,56 @@ The native runner is still the main source of truth for transport-level speed be
 
 For the reasoning behind these benchmark layers, implementation notes, and extension tips, see [benchmarking_guide.md](./benchmarking_guide.md).
 
+## Checker Query Performance Tips
+
+Type-aware lint rules and editor integrations usually spend time in small
+checker lookups after a snapshot is already warm. Avoid N+1 loops over
+individual relation primitives in those hot paths.
+
+Keep using the single-call primitives for one-off scripts:
+
+```ts
+const type = client.getTypeAtPosition(snapshot, project, file, position);
+const symbol = client.getPropertyOfType(snapshot, project, type.id, "value");
+```
+
+For repeated work in the same `(snapshot, project)`, prefer the batch helpers
+from `@corsa-bind/napi`:
+
+```ts
+import { resolveCheckerBatch } from "@corsa-bind/napi";
+
+const facts = resolveCheckerBatch(client, { snapshot, project: project.id }, [
+  { key: "nodes", kind: "typesAtPositions", file, positions },
+  { key: "symbols", kind: "symbolsAtPositions", file, positions },
+  { key: "callable", kind: "propertyOfType", type: candidateType, name: "call" },
+  { key: "safe", kind: "isTypeAssignableTo", source: sourceType, target: targetType },
+]);
+```
+
+`resolveCheckerBatch` reduces common fan-out before it crosses the process
+boundary:
+
+- repeated `typeAtPosition` and `symbolAtPosition` queries are grouped by file
+  and sent as `getTypesAtPositions` / `getSymbolsAtPositions`;
+- `typeOfSymbol` and `typesOfSymbols` fan-out is sent through
+  `getTypesOfSymbols`;
+- follow-up relation queries such as `getPropertyOfType`,
+  `getDeclaredTypeOfSymbol`, `getSymbolOfType`, `getTypeArguments`,
+  `getConstraintOfType`, alias resolution, module exports,
+  `isTypeAssignableTo`, and `typeToString` share one upstream `batchRequests`
+  transport round trip.
+
+Use `batchCheckerRequests` when you already know the exact upstream endpoint
+sequence and want the raw `batchRequests` primitive. Keep all requests in the
+same snapshot and project unless an endpoint explicitly does not use one; mixing
+snapshots in a single batch makes handle lifetimes harder to reason about and
+usually defeats cache locality.
+
+The batching helpers do not replace `updateSnapshot`. Reuse a warm snapshot,
+batch the checker facts needed for the current rule/editor pass, and release
+the snapshot only after all follow-up relation handles have been consumed.
+
 ## Tooling Runner
 
 The tooling benchmark is the `bench_tooling_compare` binary. It tracks two workloads:

--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -9,6 +9,7 @@ import {
   CorsaApiClient,
   CorsaDistributedOrchestrator,
   CorsaVirtualDocument,
+  batchCheckerRequests,
   classifyTypeText,
   isAnyLikeTypeTexts,
   isArrayLikeTypeTexts,
@@ -17,6 +18,7 @@ import {
   isPromiseLikeTypeTexts,
   nativeLintRuleMetas,
   runNativeLintRule,
+  resolveCheckerBatch,
   splitTopLevelTypeText,
   splitTypeText,
   isUnsafeAssignment,
@@ -326,6 +328,179 @@ describe("CorsaApiClient", () => {
     }
   });
 
+  it("coalesces checker N+1 lookups through upstream batchRequests", () => {
+    const countDir = mkdtempSync(join(tmpdir(), "corsa-batch-counts-"));
+    const previousCountDir = process.env.CORSA_MOCK_COUNT_DIR;
+    process.env.CORSA_MOCK_COUNT_DIR = countDir;
+
+    const client = CorsaApiClient.spawn({
+      executable: mockBinary,
+      cwd: workspaceRoot,
+      mode: "msgpack",
+    });
+
+    try {
+      client.initialize();
+      const snapshot = client.updateSnapshot({
+        openProject: "/workspace/tsconfig.json",
+      });
+      const project = snapshot.projects[0];
+      expect(project).toBeDefined();
+
+      const rawResponses = batchCheckerRequests(client, [
+        {
+          method: "getPropertyOfType",
+          params: {
+            snapshot: snapshot.snapshot,
+            project: project.id,
+            type: "t0000000000000010",
+            name: "length",
+          },
+        },
+        {
+          method: "isTypeAssignableTo",
+          params: {
+            snapshot: snapshot.snapshot,
+            project: project.id,
+            source: "t0000000000000010",
+            target: "t0000000000000010",
+          },
+        },
+      ]);
+      expect(rawResponses.map((response) => response.method)).toEqual([
+        "getPropertyOfType",
+        "isTypeAssignableTo",
+      ]);
+      expect(rawResponses[0].result).toEqual(expect.objectContaining({ name: "value" }));
+      expect(rawResponses[1].result).toBe(true);
+
+      const file = "/workspace/src/index.ts";
+      const results = resolveCheckerBatch(
+        client,
+        { snapshot: snapshot.snapshot, project: project.id },
+        [
+          { key: "type", kind: "typeAtPosition", file, position: 1 },
+          { key: "same-type", kind: "typeAtPosition", file, position: 1 },
+          { key: "types", kind: "typesAtPositions", file, positions: [1, 2, 1] },
+          { key: "symbol", kind: "symbolAtPosition", file, position: 1 },
+          { key: "symbol-types", kind: "typesOfSymbols", symbols: ["s1", "s2", "s1"] },
+          { key: "symbol-type", kind: "typeOfSymbol", symbol: "s1" },
+          { key: "type-symbol", kind: "symbolOfType", type: "t0000000000000010" },
+          { key: "declared", kind: "declaredTypeOfSymbol", symbol: "s1" },
+          { key: "property", kind: "propertyOfType", type: "t0000000000000010", name: "length" },
+          {
+            key: "type-arguments",
+            kind: "typeArguments",
+            type: "t0000000000000010",
+            objectFlags: 1 << 2,
+          },
+          {
+            key: "skipped-type-arguments",
+            kind: "typeArguments",
+            type: "t0000000000000010",
+            objectFlags: 0,
+          },
+          { key: "constraint", kind: "constraintOfType", type: "t0000000000000010" },
+          {
+            key: "assignable",
+            kind: "isTypeAssignableTo",
+            source: "t0000000000000010",
+            target: "t0000000000000010",
+          },
+          { key: "alias", kind: "aliasedSymbol", symbol: "s1" },
+          { key: "immediate-alias", kind: "immediateAliasedSymbol", symbol: "s1" },
+          { key: "exports", kind: "exportsOfModule", symbol: "s1" },
+          { key: "display", kind: "typeToString", type: "t0000000000000010" },
+        ],
+      );
+      const byKey = new Map(results.map((result) => [result.key, result]));
+      expect(byKey.get("type")).toEqual(
+        expect.objectContaining({ result: expect.objectContaining({ id: "t0000000000000001" }) }),
+      );
+      expect(byKey.get("same-type")).toEqual(
+        expect.objectContaining({ result: expect.objectContaining({ id: "t0000000000000001" }) }),
+      );
+      expect(byKey.get("types")).toEqual(
+        expect.objectContaining({
+          result: [
+            expect.objectContaining({ id: "t0000000000000001" }),
+            expect.objectContaining({ id: "t0000000000000001" }),
+            expect.objectContaining({ id: "t0000000000000001" }),
+          ],
+        }),
+      );
+      expect(byKey.get("symbol")).toEqual(
+        expect.objectContaining({ result: expect.objectContaining({ name: "value" }) }),
+      );
+      expect(byKey.get("symbol-types")).toEqual(
+        expect.objectContaining({
+          result: [
+            expect.objectContaining({ id: "t0000000000000001" }),
+            expect.objectContaining({ id: "t0000000000000001" }),
+            expect.objectContaining({ id: "t0000000000000001" }),
+          ],
+        }),
+      );
+      expect(byKey.get("symbol-type")).toEqual(
+        expect.objectContaining({ result: expect.objectContaining({ id: "t0000000000000001" }) }),
+      );
+      expect(byKey.get("type-symbol")).toEqual(
+        expect.objectContaining({ result: expect.objectContaining({ name: "value" }) }),
+      );
+      expect(byKey.get("declared")).toEqual(
+        expect.objectContaining({ result: expect.objectContaining({ id: "t0000000000000001" }) }),
+      );
+      expect(byKey.get("property")).toEqual(
+        expect.objectContaining({ result: expect.objectContaining({ name: "value" }) }),
+      );
+      expect(byKey.get("type-arguments")).toEqual(
+        expect.objectContaining({
+          result: [expect.objectContaining({ id: "t0000000000000001" })],
+        }),
+      );
+      expect(byKey.get("skipped-type-arguments")).toEqual(expect.objectContaining({ result: [] }));
+      expect(byKey.get("constraint")).toEqual(
+        expect.objectContaining({ result: expect.objectContaining({ id: "t0000000000000001" }) }),
+      );
+      expect(byKey.get("assignable")).toEqual(expect.objectContaining({ result: true }));
+      expect(byKey.get("alias")).toEqual(
+        expect.objectContaining({ result: expect.objectContaining({ name: "value" }) }),
+      );
+      expect(byKey.get("immediate-alias")).toEqual(
+        expect.objectContaining({ result: expect.objectContaining({ name: "value" }) }),
+      );
+      expect(byKey.get("exports")).toEqual(
+        expect.objectContaining({
+          result: [expect.objectContaining({ name: "value" })],
+        }),
+      );
+      expect(byKey.get("display")).toEqual(expect.objectContaining({ result: "type:string" }));
+
+      expect(readMockCallCount(countDir, "batchRequests")).toBe(2);
+      expect(readMockCallCount(countDir, "getTypeAtPosition")).toBe(0);
+      expect(readMockCallCount(countDir, "getTypesAtPositions")).toBe(0);
+      expect(readMockCallCount(countDir, "getTypeOfSymbol")).toBe(0);
+      expect(readMockCallCount(countDir, "getTypesOfSymbols")).toBe(0);
+      expect(readMockCallCount(countDir, "getSymbolOfType")).toBe(0);
+      expect(readMockCallCount(countDir, "getTypeArguments")).toBe(0);
+      expect(readMockCallCount(countDir, "getConstraintOfType")).toBe(0);
+      expect(readMockCallCount(countDir, "getPropertyOfType")).toBe(0);
+
+      client.releaseHandle(snapshot.snapshot);
+    } finally {
+      try {
+        client.close();
+      } finally {
+        if (previousCountDir === undefined) {
+          delete process.env.CORSA_MOCK_COUNT_DIR;
+        } else {
+          process.env.CORSA_MOCK_COUNT_DIR = previousCountDir;
+        }
+        rmSync(countDir, { force: true, recursive: true });
+      }
+    }
+  });
+
   it("roundtrips through the mock corsa binary without blocking on async APIs", async () => {
     const client = await CorsaApiClient.spawnAsync({
       executable: mockBinary,
@@ -594,6 +769,16 @@ function writeContentMapperProject(projectRoot: string): void {
 function readText(source: Uint8Array | null): string {
   expect(source).not.toBeNull();
   return Buffer.from(source!).toString("utf8");
+}
+
+function readMockCallCount(dir: string, method: string): number {
+  const file = join(dir, `${method}.count`);
+  if (!existsSync(file)) {
+    return 0;
+  }
+  return readFileSync(file, "utf8")
+    .split("\n")
+    .filter((line) => line.trim() === "1").length;
 }
 
 async function removeTemporaryProject(projectRoot: string): Promise<void> {

--- a/src/bindings/nodejs/corsa_node/ts/index.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.ts
@@ -2,11 +2,17 @@ import * as nativeModule from "../index.js";
 
 import type {
   ApiClientOptions,
+  CheckerBatchQuery,
+  CheckerBatchRequest,
+  CheckerBatchResponse,
+  CheckerBatchResult,
+  CheckerBatchScope,
   ConfigResponse,
   InitializeResponse,
   NativeLintDiagnostic,
   NativeLintNode,
   NativeLintRuleMeta,
+  ResolvedCheckerBatchItem,
   SymbolResponse,
   TypeResponse,
   TypeTextKind,
@@ -20,6 +26,9 @@ import type {
 const binding = (
   "default" in nativeModule ? nativeModule.default : nativeModule
 ) as typeof import("../index.js");
+
+const OBJECT_FLAGS_REFERENCE = 1 << 2;
+const OBJECT_FLAGS_MAPPED = 1 << 5;
 
 type CorsaApiClientConstructor = {
   spawn(options: ApiClientOptions): CorsaApiClient;
@@ -309,6 +318,111 @@ export const isErrorLikeTypeTexts = binding.isErrorLikeTypeTexts as (
   propertyNames?: readonly string[],
 ) => boolean;
 
+export type CheckerBatchCapableClient = Pick<CorsaApiClient, "callJson">;
+export type AsyncCheckerBatchCapableClient = Pick<CorsaApiClient, "callJsonAsync">;
+type CheckerBatchRoute = (response: CheckerBatchResponse) => void;
+
+interface PositionBatchGroup {
+  file: string;
+  positions: number[];
+  positionSet: Set<number>;
+  routes: PositionBatchRoute[];
+}
+
+interface PositionBatchRoute {
+  query: CheckerBatchQuery;
+  queryIndex: number;
+  positions: readonly number[];
+  single: boolean;
+}
+
+interface SymbolTypeBatchGroup {
+  symbols: string[];
+  symbolSet: Set<string>;
+  routes: SymbolTypeBatchRoute[];
+}
+
+interface SymbolTypeBatchRoute {
+  query: CheckerBatchQuery;
+  queryIndex: number;
+  symbols: readonly string[];
+  single: boolean;
+}
+
+interface CheckerBatchPlan {
+  requests: CheckerBatchRequest[];
+  resolve(responses: CheckerBatchResponse[]): ResolvedCheckerBatchItem[];
+}
+
+/**
+ * Sends multiple raw checker endpoint calls through upstream `batchRequests`.
+ *
+ * This keeps the original typed primitives available while giving hot paths a
+ * single transport round trip for relation-heavy workflows.
+ */
+export function batchCheckerRequests(
+  client: CheckerBatchCapableClient,
+  requests: readonly CheckerBatchRequest[],
+): CheckerBatchResponse[] {
+  if (requests.length === 0) {
+    return [];
+  }
+  const response = client.callJson<{ responses: unknown }>("batchRequests", {
+    requests: requests.map(normalizeCheckerBatchRequest),
+  });
+  return normalizeCheckerBatchResponses(response, requests.length);
+}
+
+/**
+ * Async counterpart of {@link batchCheckerRequests}.
+ */
+export async function batchCheckerRequestsAsync(
+  client: AsyncCheckerBatchCapableClient,
+  requests: readonly CheckerBatchRequest[],
+): Promise<CheckerBatchResponse[]> {
+  if (requests.length === 0) {
+    return [];
+  }
+  const response = await client.callJsonAsync<{ responses: unknown }>("batchRequests", {
+    requests: requests.map(normalizeCheckerBatchRequest),
+  });
+  return normalizeCheckerBatchResponses(response, requests.length);
+}
+
+/**
+ * Resolves common project-scoped checker lookups as one coalesced batch.
+ *
+ * Position queries are grouped per source file and symbol-type queries use
+ * `getTypesOfSymbols`, so callers can express per-node facts without writing
+ * their own N+1 loop.
+ */
+export function resolveCheckerBatch(
+  client: CheckerBatchCapableClient,
+  scope: CheckerBatchScope,
+  queries: readonly CheckerBatchQuery[],
+): ResolvedCheckerBatchItem[] {
+  const plan = planCheckerBatch(scope, queries);
+  if (plan.requests.length === 0) {
+    return plan.resolve([]);
+  }
+  return plan.resolve(batchCheckerRequests(client, plan.requests));
+}
+
+/**
+ * Async counterpart of {@link resolveCheckerBatch}.
+ */
+export async function resolveCheckerBatchAsync(
+  client: AsyncCheckerBatchCapableClient,
+  scope: CheckerBatchScope,
+  queries: readonly CheckerBatchQuery[],
+): Promise<ResolvedCheckerBatchItem[]> {
+  const plan = planCheckerBatch(scope, queries);
+  if (plan.requests.length === 0) {
+    return plan.resolve([]);
+  }
+  return plan.resolve(await batchCheckerRequestsAsync(client, plan.requests));
+}
+
 export const Utils = Object.freeze({
   classifyTypeText,
   splitTopLevelTypeText,
@@ -326,3 +440,481 @@ export const Utils = Object.freeze({
 
 export default binding;
 export type * from "./types";
+
+function normalizeCheckerBatchRequest(request: CheckerBatchRequest): CheckerBatchRequest {
+  if (request.params === undefined) {
+    return { method: request.method };
+  }
+  return { method: request.method, params: request.params };
+}
+
+function normalizeCheckerBatchResponses(
+  response: { responses?: unknown },
+  expectedLength: number,
+): CheckerBatchResponse[] {
+  if (typeof response !== "object" || response === null) {
+    throw new Error("batchRequests returned a malformed response");
+  }
+  const responses = response.responses;
+  if (!Array.isArray(responses)) {
+    throw new Error("batchRequests returned a malformed response list");
+  }
+  if (responses.length !== expectedLength) {
+    throw new Error(
+      `batchRequests returned ${responses.length} responses for ${expectedLength} requests`,
+    );
+  }
+  return responses.map((item, index) => {
+    if (typeof item !== "object" || item === null) {
+      throw new Error(`batchRequests response ${index} is not an object`);
+    }
+    const record = item as Record<string, unknown>;
+    const method = typeof record.method === "string" ? record.method : "";
+    const normalized: CheckerBatchResponse = { method };
+    if (typeof record.error === "string" && record.error.length > 0) {
+      normalized.error = record.error;
+    }
+    if ("result" in record) {
+      normalized.result = record.result;
+    }
+    return normalized;
+  });
+}
+
+function planCheckerBatch(
+  scope: CheckerBatchScope,
+  queries: readonly CheckerBatchQuery[],
+): CheckerBatchPlan {
+  const results: Array<ResolvedCheckerBatchItem | undefined> = [];
+  results.length = queries.length;
+  const requests: CheckerBatchRequest[] = [];
+  const requestRoutes: CheckerBatchRoute[][] = [];
+  const directRequestIndexes = new Map<string, number>();
+  const typePositionGroups = new Map<string, PositionBatchGroup>();
+  const symbolPositionGroups = new Map<string, PositionBatchGroup>();
+  const symbolTypeGroup: SymbolTypeBatchGroup = {
+    symbols: [],
+    symbolSet: new Set(),
+    routes: [],
+  };
+
+  const addRequest = (request: CheckerBatchRequest, route: CheckerBatchRoute): void => {
+    requests.push(request);
+    requestRoutes.push([route]);
+  };
+  const addDirectRequest = (
+    query: CheckerBatchQuery,
+    queryIndex: number,
+    method: string,
+    params: Record<string, unknown>,
+    transform: (result: unknown) => CheckerBatchResult = directBatchResult,
+  ): void => {
+    const compactParams = omitUndefinedProperties(params);
+    const requestKey = `${method}\0${JSON.stringify(compactParams)}`;
+    const route = (response: CheckerBatchResponse): void => {
+      setResponseResult(results, queryIndex, query, response, transform);
+    };
+    const existingIndex = directRequestIndexes.get(requestKey);
+    if (existingIndex !== undefined) {
+      requestRoutes[existingIndex]?.push(route);
+      return;
+    }
+    directRequestIndexes.set(requestKey, requests.length);
+    addRequest({ method, params: compactParams }, route);
+  };
+
+  queries.forEach((query, queryIndex) => {
+    switch (query.kind) {
+      case "typeAtPosition":
+        addPositionBatchQuery(
+          typePositionGroups,
+          query,
+          queryIndex,
+          query.file,
+          [query.position],
+          true,
+        );
+        break;
+      case "typesAtPositions":
+        if (query.positions.length === 0) {
+          results[queryIndex] = { key: query.key, kind: query.kind, result: [] };
+        } else {
+          addPositionBatchQuery(
+            typePositionGroups,
+            query,
+            queryIndex,
+            query.file,
+            query.positions,
+            false,
+          );
+        }
+        break;
+      case "symbolAtPosition":
+        addPositionBatchQuery(
+          symbolPositionGroups,
+          query,
+          queryIndex,
+          query.file,
+          [query.position],
+          true,
+        );
+        break;
+      case "symbolsAtPositions":
+        if (query.positions.length === 0) {
+          results[queryIndex] = { key: query.key, kind: query.kind, result: [] };
+        } else {
+          addPositionBatchQuery(
+            symbolPositionGroups,
+            query,
+            queryIndex,
+            query.file,
+            query.positions,
+            false,
+          );
+        }
+        break;
+      case "typeOfSymbol":
+        addSymbolTypeBatchQuery(symbolTypeGroup, query, queryIndex, [query.symbol], true);
+        break;
+      case "typesOfSymbols":
+        if (query.symbols.length === 0) {
+          results[queryIndex] = { key: query.key, kind: query.kind, result: [] };
+        } else {
+          addSymbolTypeBatchQuery(symbolTypeGroup, query, queryIndex, query.symbols, false);
+        }
+        break;
+      case "symbolOfType":
+        addDirectRequest(query, queryIndex, "getSymbolOfType", {
+          snapshot: scope.snapshot,
+          project: scope.project,
+          type: query.type,
+        });
+        break;
+      case "declaredTypeOfSymbol":
+        addDirectRequest(query, queryIndex, "getDeclaredTypeOfSymbol", {
+          snapshot: scope.snapshot,
+          project: scope.project,
+          symbol: query.symbol,
+        });
+        break;
+      case "aliasedSymbol":
+        addDirectRequest(query, queryIndex, "getAliasedSymbol", {
+          snapshot: scope.snapshot,
+          project: scope.project,
+          symbol: query.symbol,
+        });
+        break;
+      case "immediateAliasedSymbol":
+        addDirectRequest(query, queryIndex, "getImmediateAliasedSymbol", {
+          snapshot: scope.snapshot,
+          project: scope.project,
+          symbol: query.symbol,
+        });
+        break;
+      case "exportsOfModule":
+        addDirectRequest(
+          query,
+          queryIndex,
+          "getExportsOfModule",
+          {
+            snapshot: scope.snapshot,
+            project: scope.project,
+            symbol: query.symbol,
+          },
+          arrayBatchResult,
+        );
+        break;
+      case "propertyOfType":
+        addDirectRequest(query, queryIndex, "getPropertyOfType", {
+          snapshot: scope.snapshot,
+          project: scope.project,
+          type: query.type,
+          name: query.name,
+        });
+        break;
+      case "typeArguments":
+        if (
+          query.objectFlags !== undefined &&
+          (query.objectFlags & (OBJECT_FLAGS_REFERENCE | OBJECT_FLAGS_MAPPED)) === 0
+        ) {
+          results[queryIndex] = { key: query.key, kind: query.kind, result: [] };
+        } else {
+          addDirectRequest(
+            query,
+            queryIndex,
+            "getTypeArguments",
+            {
+              snapshot: scope.snapshot,
+              project: scope.project,
+              type: query.type,
+            },
+            arrayBatchResult,
+          );
+        }
+        break;
+      case "constraintOfType":
+        addDirectRequest(query, queryIndex, "getConstraintOfType", {
+          snapshot: scope.snapshot,
+          project: scope.project,
+          type: query.type,
+        });
+        break;
+      case "isTypeAssignableTo":
+        addDirectRequest(query, queryIndex, "isTypeAssignableTo", {
+          snapshot: scope.snapshot,
+          project: scope.project,
+          source: query.source,
+          target: query.target,
+        });
+        break;
+      case "typeToString":
+        addDirectRequest(query, queryIndex, "typeToString", {
+          snapshot: scope.snapshot,
+          project: scope.project,
+          type: query.type,
+          location: query.location,
+          flags: query.flags,
+        });
+        break;
+    }
+  });
+
+  flushPositionBatchGroups(
+    scope,
+    typePositionGroups,
+    "getTypesAtPositions",
+    requests,
+    requestRoutes,
+    results,
+  );
+  flushPositionBatchGroups(
+    scope,
+    symbolPositionGroups,
+    "getSymbolsAtPositions",
+    requests,
+    requestRoutes,
+    results,
+  );
+  flushSymbolTypeBatchGroup(scope, symbolTypeGroup, requests, requestRoutes, results);
+
+  return {
+    requests,
+    resolve(responses) {
+      for (const [index, response] of responses.entries()) {
+        for (const route of requestRoutes[index] ?? []) {
+          route(response);
+        }
+      }
+      return queries.map((query, index) => {
+        return (
+          results[index] ?? {
+            key: query.key,
+            kind: query.kind,
+            error: "checker batch query did not produce a result",
+          }
+        );
+      });
+    },
+  };
+}
+
+function addPositionBatchQuery(
+  groups: Map<string, PositionBatchGroup>,
+  query: CheckerBatchQuery,
+  queryIndex: number,
+  file: string,
+  positions: readonly number[],
+  single: boolean,
+): void {
+  let group = groups.get(file);
+  if (!group) {
+    group = {
+      file,
+      positions: [],
+      positionSet: new Set(),
+      routes: [],
+    };
+    groups.set(file, group);
+  }
+  for (const position of positions) {
+    if (!group.positionSet.has(position)) {
+      group.positionSet.add(position);
+      group.positions.push(position);
+    }
+  }
+  group.routes.push({ query, queryIndex, positions, single });
+}
+
+function addSymbolTypeBatchQuery(
+  group: SymbolTypeBatchGroup,
+  query: CheckerBatchQuery,
+  queryIndex: number,
+  symbols: readonly string[],
+  single: boolean,
+): void {
+  for (const symbol of symbols) {
+    if (!group.symbolSet.has(symbol)) {
+      group.symbolSet.add(symbol);
+      group.symbols.push(symbol);
+    }
+  }
+  group.routes.push({ query, queryIndex, symbols, single });
+}
+
+function flushPositionBatchGroups(
+  scope: CheckerBatchScope,
+  groups: Map<string, PositionBatchGroup>,
+  method: "getTypesAtPositions" | "getSymbolsAtPositions",
+  requests: CheckerBatchRequest[],
+  requestRoutes: CheckerBatchRoute[][],
+  results: Array<ResolvedCheckerBatchItem | undefined>,
+): void {
+  for (const group of groups.values()) {
+    requests.push({
+      method,
+      params: {
+        snapshot: scope.snapshot,
+        project: scope.project,
+        file: group.file,
+        positions: group.positions,
+      },
+    });
+    requestRoutes.push([
+      (response) => {
+        if (response.error) {
+          for (const route of group.routes) {
+            results[route.queryIndex] = {
+              key: route.query.key,
+              kind: route.query.kind,
+              error: response.error,
+            };
+          }
+          return;
+        }
+        if (!Array.isArray(response.result)) {
+          const error = `${method} returned a non-array result`;
+          for (const route of group.routes) {
+            results[route.queryIndex] = {
+              key: route.query.key,
+              kind: route.query.kind,
+              error,
+            };
+          }
+          return;
+        }
+        const byPosition = new Map<number, unknown>();
+        for (const [index, position] of group.positions.entries()) {
+          byPosition.set(position, response.result[index] ?? null);
+        }
+        for (const route of group.routes) {
+          const result = route.single
+            ? (byPosition.get(route.positions[0] ?? -1) ?? null)
+            : route.positions.map((position) => byPosition.get(position) ?? null);
+          results[route.queryIndex] = {
+            key: route.query.key,
+            kind: route.query.kind,
+            result: result as CheckerBatchResult,
+          };
+        }
+      },
+    ]);
+  }
+}
+
+function flushSymbolTypeBatchGroup(
+  scope: CheckerBatchScope,
+  group: SymbolTypeBatchGroup,
+  requests: CheckerBatchRequest[],
+  requestRoutes: CheckerBatchRoute[][],
+  results: Array<ResolvedCheckerBatchItem | undefined>,
+): void {
+  if (group.symbols.length === 0) {
+    return;
+  }
+  requests.push({
+    method: "getTypesOfSymbols",
+    params: {
+      snapshot: scope.snapshot,
+      project: scope.project,
+      symbols: group.symbols,
+    },
+  });
+  requestRoutes.push([
+    (response) => {
+      if (response.error) {
+        for (const route of group.routes) {
+          results[route.queryIndex] = {
+            key: route.query.key,
+            kind: route.query.kind,
+            error: response.error,
+          };
+        }
+        return;
+      }
+      if (!Array.isArray(response.result)) {
+        const error = "getTypesOfSymbols returned a non-array result";
+        for (const route of group.routes) {
+          results[route.queryIndex] = {
+            key: route.query.key,
+            kind: route.query.kind,
+            error,
+          };
+        }
+        return;
+      }
+      const bySymbol = new Map<string, unknown>();
+      for (const [index, symbol] of group.symbols.entries()) {
+        bySymbol.set(symbol, response.result[index] ?? null);
+      }
+      for (const route of group.routes) {
+        const result = route.single
+          ? (bySymbol.get(route.symbols[0] ?? "") ?? null)
+          : route.symbols.map((symbol) => bySymbol.get(symbol) ?? null);
+        results[route.queryIndex] = {
+          key: route.query.key,
+          kind: route.query.kind,
+          result: result as CheckerBatchResult,
+        };
+      }
+    },
+  ]);
+}
+
+function setResponseResult(
+  results: Array<ResolvedCheckerBatchItem | undefined>,
+  queryIndex: number,
+  query: CheckerBatchQuery,
+  response: CheckerBatchResponse,
+  transform: (result: unknown) => CheckerBatchResult,
+): void {
+  if (response.error) {
+    results[queryIndex] = {
+      key: query.key,
+      kind: query.kind,
+      error: response.error,
+    };
+    return;
+  }
+  results[queryIndex] = {
+    key: query.key,
+    kind: query.kind,
+    result: transform(response.result),
+  };
+}
+
+function directBatchResult(result: unknown): CheckerBatchResult {
+  return (result ?? null) as CheckerBatchResult;
+}
+
+function arrayBatchResult(result: unknown): CheckerBatchResult {
+  if (result === null || result === undefined) {
+    return [];
+  }
+  return result as CheckerBatchResult;
+}
+
+function omitUndefinedProperties(input: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(input).filter((entry): entry is [string, unknown] => entry[1] !== undefined),
+  );
+}

--- a/src/bindings/nodejs/corsa_node/ts/types.ts
+++ b/src/bindings/nodejs/corsa_node/ts/types.ts
@@ -73,6 +73,136 @@ export interface SymbolResponse {
   valueDeclaration?: string;
 }
 
+export interface CheckerBatchRequest<Params = unknown> {
+  method: string;
+  params?: Params;
+}
+
+export interface CheckerBatchResponse<Result = unknown> {
+  method: string;
+  result?: Result;
+  error?: string;
+}
+
+export interface CheckerBatchScope {
+  snapshot: string;
+  project: string;
+}
+
+export type CheckerBatchQuery =
+  | {
+      key: string;
+      kind: "typeAtPosition";
+      file: string;
+      position: number;
+    }
+  | {
+      key: string;
+      kind: "typesAtPositions";
+      file: string;
+      positions: readonly number[];
+    }
+  | {
+      key: string;
+      kind: "symbolAtPosition";
+      file: string;
+      position: number;
+    }
+  | {
+      key: string;
+      kind: "symbolsAtPositions";
+      file: string;
+      positions: readonly number[];
+    }
+  | {
+      key: string;
+      kind: "typeOfSymbol";
+      symbol: string;
+    }
+  | {
+      key: string;
+      kind: "typesOfSymbols";
+      symbols: readonly string[];
+    }
+  | {
+      key: string;
+      kind: "symbolOfType";
+      type: string;
+    }
+  | {
+      key: string;
+      kind: "declaredTypeOfSymbol";
+      symbol: string;
+    }
+  | {
+      key: string;
+      kind: "aliasedSymbol";
+      symbol: string;
+    }
+  | {
+      key: string;
+      kind: "immediateAliasedSymbol";
+      symbol: string;
+    }
+  | {
+      key: string;
+      kind: "exportsOfModule";
+      symbol: string;
+    }
+  | {
+      key: string;
+      kind: "propertyOfType";
+      type: string;
+      name: string;
+    }
+  | {
+      key: string;
+      kind: "typeArguments";
+      type: string;
+      objectFlags?: number;
+    }
+  | {
+      key: string;
+      kind: "constraintOfType";
+      type: string;
+    }
+  | {
+      key: string;
+      kind: "isTypeAssignableTo";
+      source: string;
+      target: string;
+    }
+  | {
+      key: string;
+      kind: "typeToString";
+      type: string;
+      location?: string;
+      flags?: number;
+    };
+
+export type CheckerBatchResult =
+  | TypeResponse
+  | Array<TypeResponse | null>
+  | SymbolResponse
+  | Array<SymbolResponse | null>
+  | boolean
+  | string
+  | null;
+
+export type ResolvedCheckerBatchItem =
+  | {
+      key: string;
+      kind: CheckerBatchQuery["kind"];
+      result: CheckerBatchResult;
+      error?: never;
+    }
+  | {
+      key: string;
+      kind: CheckerBatchQuery["kind"];
+      result?: never;
+      error: string;
+    };
+
 export interface OverlayUpdate {
   document: DocumentIdentifier;
   text: string;

--- a/src/bindings/rust/corsa/src/bin/mock_corsa/api_async.rs
+++ b/src/bindings/rust/corsa/src/bin/mock_corsa/api_async.rs
@@ -53,6 +53,7 @@ pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
                 "currentDirectory": cwd,
             })),
             "describeCapabilities" => Some(common::capabilities()),
+            "batchRequests" => Some(batch_requests(params)),
             "parseConfigFile" => Some(parse_config(&mut reader, &mut writer, &callbacks, params)?),
             "updateSnapshot" => Some(common::snapshot_from_update_params(
                 "/workspace/tsconfig.json",
@@ -214,6 +215,77 @@ pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
             jsonrpc::write_message(&mut writer, &RawMessage::response(id, response))?;
         }
     }
+}
+
+fn batch_requests(params: Value) -> Value {
+    let responses = params
+        .get("requests")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .map(|request| {
+            let method = request
+                .get("method")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let params = request.get("params").cloned().unwrap_or(Value::Null);
+            let mut response = json!({ "method": method });
+            if let Some(error) = missing_project_error(&params) {
+                response["error"] = Value::String(error.message.to_string());
+                return response;
+            }
+            response["result"] = batch_request_result(method, &params).unwrap_or(Value::Null);
+            response
+        })
+        .collect::<Vec<_>>();
+    json!({ "responses": responses })
+}
+
+fn batch_request_result(method: &str, params: &Value) -> Option<Value> {
+    match method {
+        "getSymbolsAtPositions" | "getSymbolsAtLocations" => {
+            Some(json!([common::symbol("value"), Value::Null]))
+        }
+        "getTypeOfSymbol"
+        | "getDeclaredTypeOfSymbol"
+        | "getTypeAtPosition"
+        | "getTypeAtLocation"
+        | "getConstraintOfType" => Some(common::type_response("t0000000000000001")),
+        "getTypeArguments" => Some(repeated_type_responses(1)),
+        "getTypesOfSymbols" | "getTypeAtLocations" | "getTypesAtPositions" => {
+            Some(repeated_type_responses(batch_request_item_count(params)))
+        }
+        "getSymbolOfType"
+        | "getAliasedSymbol"
+        | "getImmediateAliasedSymbol"
+        | "getPropertyOfType" => Some(common::symbol("value")),
+        "getExportsOfModule" => Some(json!([common::symbol("value")])),
+        "isTypeAssignableTo" => Some(json!(true)),
+        "typeToString" => Some(json!("type:string")),
+        _ => None,
+    }
+}
+
+fn batch_request_item_count(params: &Value) -> usize {
+    params
+        .as_object()
+        .and_then(|value| {
+            value
+                .get("symbols")
+                .or_else(|| value.get("locations"))
+                .or_else(|| value.get("positions"))
+                .and_then(Value::as_array)
+        })
+        .map(Vec::len)
+        .unwrap_or(1)
+}
+
+fn repeated_type_responses(count: usize) -> Value {
+    Value::Array(
+        (0..count)
+            .map(|_| common::type_response("t0000000000000001"))
+            .collect(),
+    )
 }
 
 /// Mirrors upstream's per-project handle resolution so project-less lookups

--- a/src/bindings/rust/corsa/src/bin/mock_corsa/msgpack.rs
+++ b/src/bindings/rust/corsa/src/bin/mock_corsa/msgpack.rs
@@ -32,6 +32,7 @@ pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
                 "currentDirectory": cwd,
             }),
             "describeCapabilities" => crate::common::capabilities(),
+            "batchRequests" => batch_requests(params),
             "parseConfigFile" => parse_config(&mut reader, &mut writer, &callbacks, params)?,
             "updateSnapshot" => {
                 crate::common::snapshot_from_update_params("/workspace/tsconfig.json", &params)
@@ -81,6 +82,77 @@ pub fn run(cwd: String, callbacks: Vec<String>) -> Result<()> {
             &serde_json::to_vec(&response)?,
         )?;
     }
+}
+
+fn batch_requests(params: Value) -> Value {
+    let responses = params
+        .get("requests")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .map(|request| {
+            let method = request
+                .get("method")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            json!({
+                "method": method,
+                "result": batch_request_result(
+                    method,
+                    request.get("params").unwrap_or(&Value::Null),
+                )
+                .unwrap_or(Value::Null),
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({ "responses": responses })
+}
+
+fn batch_request_result(method: &str, params: &Value) -> Option<Value> {
+    match method {
+        "getSymbolsAtPositions" | "getSymbolsAtLocations" => {
+            Some(json!([crate::common::symbol("value"), Value::Null]))
+        }
+        "getTypeOfSymbol"
+        | "getDeclaredTypeOfSymbol"
+        | "getTypeAtPosition"
+        | "getTypeAtLocation"
+        | "getConstraintOfType" => Some(crate::common::type_response("t0000000000000001")),
+        "getTypeArguments" => Some(repeated_type_responses(1)),
+        "getTypesOfSymbols" | "getTypeAtLocations" | "getTypesAtPositions" => {
+            Some(repeated_type_responses(batch_request_item_count(params)))
+        }
+        "getSymbolOfType"
+        | "getAliasedSymbol"
+        | "getImmediateAliasedSymbol"
+        | "getPropertyOfType" => Some(crate::common::symbol("value")),
+        "getExportsOfModule" => Some(json!([crate::common::symbol("value")])),
+        "isTypeAssignableTo" => Some(json!(true)),
+        "typeToString" => Some(json!("type:string")),
+        _ => None,
+    }
+}
+
+fn batch_request_item_count(params: &Value) -> usize {
+    params
+        .as_object()
+        .and_then(|value| {
+            value
+                .get("symbols")
+                .or_else(|| value.get("locations"))
+                .or_else(|| value.get("positions"))
+                .and_then(Value::as_array)
+        })
+        .map(Vec::len)
+        .unwrap_or(1)
+}
+
+fn repeated_type_responses(count: usize) -> Value {
+    Value::Array(
+        (0..count)
+            .map(|_| crate::common::type_response("t0000000000000001"))
+            .collect(),
+    )
 }
 
 fn record_params(method: &str, params: &Value) {


### PR DESCRIPTION
## Summary

- add `batchCheckerRequests` / `batchCheckerRequestsAsync` over upstream `batchRequests`
- add `resolveCheckerBatch` / `resolveCheckerBatchAsync` for project-scoped checker hot paths; it coalesces repeated position queries, uses `getTypesOfSymbols` for symbol type fan-out, and batches relation follow-ups such as property, type arguments, constraints, aliases, module exports, assignability, and type stringification
- document the N+1 avoidance pattern in the Node binding guide and Performance tips

## Validation

- `PATH=/Users/nishimura/.local/share/mise/installs/node/24.15.0/bin:$PATH CI=true vp check`
- `PATH=/Users/nishimura/.local/share/mise/installs/node/24.15.0/bin:$PATH CI=true vitest run --config ./vite.config.ts src/bindings/nodejs/corsa_node/ts/index.test.ts`
- `PATH=/Users/nishimura/.local/share/mise/installs/node/24.15.0/bin:$PATH CI=true vp run -w test_ts`
- `PATH=/Users/nishimura/.local/share/mise/installs/node/24.15.0/bin:$PATH CI=true vp run -w docs_build`
- `GOTOOLCHAIN=auto CI=true cargo test --workspace --quiet`
- `PATH=/Users/nishimura/.local/share/mise/installs/node/24.15.0/bin:$PWD/node_modules/.bin:$PATH GOTOOLCHAIN=auto CI=true vp run -w release_dry_run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added synchronous and asynchronous batch checker APIs for combining type, symbol, relation, assignability, and rendering queries.
  * Batch processing coalesces repeated lookups and reduces transport round trips for type-aware workflows.

* **Documentation**
  * Added usage guidance and performance recommendations for checker query batching, snapshots, and follow-up relation queries.

* **Tests**
  * Added coverage verifying batched requests produce correct results while avoiding redundant individual lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->