### PR TITLE
fix(mock): preserve checker batch response contracts

### DIFF
--- a/src/bindings/nodejs/corsa_node/ts/index.test.ts
+++ b/src/bindings/nodejs/corsa_node/ts/index.test.ts
@@ -366,13 +366,38 @@ describe("CorsaApiClient", () => {
             target: "t0000000000000010",
           },
         },
+        {
+          method: "getSymbolsAtPositions",
+          params: {
+            snapshot: snapshot.snapshot,
+            project: project.id,
+            file: "/workspace/src/index.ts",
+            positions: [1, 2, 3],
+          },
+        },
+        {
+          method: "getPropertyOfType",
+          params: {
+            snapshot: snapshot.snapshot,
+            type: "t0000000000000010",
+            name: "length",
+          },
+        },
       ]);
       expect(rawResponses.map((response) => response.method)).toEqual([
         "getPropertyOfType",
         "isTypeAssignableTo",
+        "getSymbolsAtPositions",
+        "getPropertyOfType",
       ]);
       expect(rawResponses[0].result).toEqual(expect.objectContaining({ name: "value" }));
       expect(rawResponses[1].result).toBe(true);
+      expect(rawResponses[2].result).toEqual([
+        expect.objectContaining({ name: "value" }),
+        expect.objectContaining({ name: "value" }),
+        expect.objectContaining({ name: "value" }),
+      ]);
+      expect(rawResponses[3].error).toMatch("empty project ID for type handle");
 
       const file = "/workspace/src/index.ts";
       const results = resolveCheckerBatch(
@@ -383,6 +408,7 @@ describe("CorsaApiClient", () => {
           { key: "same-type", kind: "typeAtPosition", file, position: 1 },
           { key: "types", kind: "typesAtPositions", file, positions: [1, 2, 1] },
           { key: "symbol", kind: "symbolAtPosition", file, position: 1 },
+          { key: "symbols", kind: "symbolsAtPositions", file, positions: [1, 2, 3] },
           { key: "symbol-types", kind: "typesOfSymbols", symbols: ["s1", "s2", "s1"] },
           { key: "symbol-type", kind: "typeOfSymbol", symbol: "s1" },
           { key: "type-symbol", kind: "symbolOfType", type: "t0000000000000010" },
@@ -431,6 +457,15 @@ describe("CorsaApiClient", () => {
       );
       expect(byKey.get("symbol")).toEqual(
         expect.objectContaining({ result: expect.objectContaining({ name: "value" }) }),
+      );
+      expect(byKey.get("symbols")).toEqual(
+        expect.objectContaining({
+          result: [
+            expect.objectContaining({ name: "value" }),
+            expect.objectContaining({ name: "value" }),
+            expect.objectContaining({ name: "value" }),
+          ],
+        }),
       );
       expect(byKey.get("symbol-types")).toEqual(
         expect.objectContaining({

--- a/src/bindings/rust/corsa/src/bin/mock_corsa/api_async.rs
+++ b/src/bindings/rust/corsa/src/bin/mock_corsa/api_async.rs
@@ -244,7 +244,7 @@ fn batch_requests(params: Value) -> Value {
 fn batch_request_result(method: &str, params: &Value) -> Option<Value> {
     match method {
         "getSymbolsAtPositions" | "getSymbolsAtLocations" => {
-            Some(json!([common::symbol("value"), Value::Null]))
+            Some(repeated_symbol_responses(batch_request_item_count(params)))
         }
         "getTypeOfSymbol"
         | "getDeclaredTypeOfSymbol"
@@ -286,6 +286,10 @@ fn repeated_type_responses(count: usize) -> Value {
             .map(|_| common::type_response("t0000000000000001"))
             .collect(),
     )
+}
+
+fn repeated_symbol_responses(count: usize) -> Value {
+    Value::Array((0..count).map(|_| common::symbol("value")).collect())
 }
 
 /// Mirrors upstream's per-project handle resolution so project-less lookups

--- a/src/bindings/rust/corsa/src/bin/mock_corsa/msgpack.rs
+++ b/src/bindings/rust/corsa/src/bin/mock_corsa/msgpack.rs
@@ -95,14 +95,14 @@ fn batch_requests(params: Value) -> Value {
                 .get("method")
                 .and_then(Value::as_str)
                 .unwrap_or_default();
-            json!({
-                "method": method,
-                "result": batch_request_result(
-                    method,
-                    request.get("params").unwrap_or(&Value::Null),
-                )
-                .unwrap_or(Value::Null),
-            })
+            let params = request.get("params").cloned().unwrap_or(Value::Null);
+            let mut response = json!({ "method": method });
+            if let Some(error) = crate::common::missing_project_message(&params) {
+                response["error"] = Value::String(error);
+                return response;
+            }
+            response["result"] = batch_request_result(method, &params).unwrap_or(Value::Null);
+            response
         })
         .collect::<Vec<_>>();
     json!({ "responses": responses })
@@ -111,7 +111,7 @@ fn batch_requests(params: Value) -> Value {
 fn batch_request_result(method: &str, params: &Value) -> Option<Value> {
     match method {
         "getSymbolsAtPositions" | "getSymbolsAtLocations" => {
-            Some(json!([crate::common::symbol("value"), Value::Null]))
+            Some(repeated_symbol_responses(batch_request_item_count(params)))
         }
         "getTypeOfSymbol"
         | "getDeclaredTypeOfSymbol"
@@ -153,6 +153,10 @@ fn repeated_type_responses(count: usize) -> Value {
             .map(|_| crate::common::type_response("t0000000000000001"))
             .collect(),
     )
+}
+
+fn repeated_symbol_responses(count: usize) -> Value {
+    Value::Array((0..count).map(|_| crate::common::symbol("value")).collect())
 }
 
 fn record_params(method: &str, params: &Value) {


### PR DESCRIPTION
## Summary
- preserve getSymbolsAtPositions/getSymbolsAtLocations response cardinality inside mock batchRequests
- return per-request missing-project errors from msgpack batchRequests to match JSON-RPC mock behavior
- add Node integration coverage for symbol batch cardinality and project-less handle errors

## Validation
- cargo fmt --all -- --check
- cargo build -p corsa --bin mock_corsa
- CI=true ./node_modules/.bin/vitest run --config ./vite.config.ts src/bindings/nodejs/corsa_node/ts/index.test.ts
- CI=true ./node_modules/.bin/vp check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791092110&installation_model_id=422833&pr_number=481&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F481&signature=89d568ce70839e90a1619ea24f1a8019d352cc0742b0c93ff4878fb3cecd6c3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->