### PR TITLE
test(client): validate the span map against a real mapper output

### DIFF
--- a/docs/content_mappers.md
+++ b/docs/content_mappers.md
@@ -74,6 +74,23 @@ is re-run only when a file's content changes. `dynamicConfig` says the mapper
 resolves configuration of its own at `openProject` time and reports the files
 that invalidate it.
 
+`dynamicConfig` is a two-way contract on the `openProject` response, and
+upstream rejects the project when either side of it is broken
+(`internal/contentmapper/hostimpl.go`):
+
+| `dynamicConfig` | `configIdentity`        | `watchedFiles`           |
+| --------------- | ----------------------- | ------------------------ |
+| `true`          | **required**, non-empty | optional, absolute paths |
+| `false`         | must be absent          | must be absent           |
+
+`configIdentity` is a stable fingerprint of every piece of dynamic
+configuration that can affect a transform; TypeScript combines it with the
+mapper identity, its options, and the declared `compilerOptions` into the cache
+key, so a mapper that reports the same identity is not re-run.
+`watchedFiles` are the files whose changes may alter that identity or the
+transform output, and **must be absolute** — a relative entry is rejected as
+well.
+
 `corsa-bind` reads the declared mappers back off a parsed config:
 
 ```rust
@@ -105,12 +122,21 @@ segments as it emits text:
 ```ts
 import { MappedCodeBuilder, runContentMapper } from "ts-content-mapper";
 
+const OPEN = "<script>";
+const CLOSE = "</script>";
+
 runContentMapper({
   diagnosticSource: "demo",
   transform({ content }) {
-    const start = content.indexOf("<script>") + "<script>".length;
-    const end = content.indexOf("</script>", start);
-    return new MappedCodeBuilder(content).appendVerbatim(start, end).build(".ts");
+    const builder = new MappedCodeBuilder(content);
+    const open = content.indexOf(OPEN);
+    const end = open < 0 ? -1 : content.indexOf(CLOSE, open + OPEN.length);
+    // A file with no complete `<script>` block maps to empty TypeScript rather
+    // than to a reversed range: `indexOf` returns -1 on both misses.
+    if (end < 0) {
+      return builder.build(".ts");
+    }
+    return builder.appendVerbatim(open + OPEN.length, end).build(".ts");
   },
 });
 ```

--- a/docs/content_mappers.md
+++ b/docs/content_mappers.md
@@ -58,9 +58,21 @@ The mapper package's own `package.json` says how to run it:
 {
   "name": "vue-mapper",
   "version": "1.2.3",
-  "typescript": { "contentMapper": { "exec": ["node", "./mapper.mjs"] } }
+  "typescript": {
+    "contentMapper": {
+      "exec": ["node", "./mapper.mjs"],
+      "compilerOptions": ["jsx", "target"],
+      "dynamicConfig": false
+    }
+  }
 }
 ```
+
+`compilerOptions` names the compiler options whose values change the mapper's
+output; TypeScript folds them into the cache key, so a mapper that declares none
+is re-run only when a file's content changes. `dynamicConfig` says the mapper
+resolves configuration of its own at `openProject` time and reports the files
+that invalidate it.
 
 `corsa-bind` reads the declared mappers back off a parsed config:
 
@@ -82,6 +94,44 @@ Both read the `contentMappers` array out of the raw `tsconfig` object the
 runtime returns alongside the normalized compiler options, and both return an
 empty list when the project declares none — including on runtimes that predate
 content mappers.
+
+## Writing a mapper
+
+`corsa-bind` is the consuming side. To author the mapper itself, the
+[`ts-content-mapper`](https://github.com/sxzz/ts-content-mapper) package wraps
+the stdio JSON-RPC protocol and gives you a `MappedCodeBuilder` that records
+segments as it emits text:
+
+```ts
+import { MappedCodeBuilder, runContentMapper } from "ts-content-mapper";
+
+runContentMapper({
+  diagnosticSource: "demo",
+  transform({ content }) {
+    const start = content.indexOf("<script>") + "<script>".length;
+    const end = content.indexOf("</script>", start);
+    return new MappedCodeBuilder(content).appendVerbatim(start, end).build(".ts");
+  },
+});
+```
+
+Because the builder merges adjacent verbatim runs, a real mapper usually emits
+very few, very large segments — the example above produces exactly one for the
+whole `<script>` body. `appendAtom` and `appendAlias` cover generated text that
+stands in for an original span, and `appendAnchored` produces an atom over a
+zero-length original range, which is how a mapper points a generated declaration
+at an insertion point. `corsa-bind` answers queries for all of these, including
+the zero-length case.
+
+> [!IMPORTANT]
+> The mapper-facing protocol and the API payload share a vocabulary but are not
+> the same wire format. Span map segments are the same tuple on both sides, but
+> diagnostic directives are not: a mapper sends
+> `[originalStart, originalLength, virtualStart, virtualEnd, policy, unusedExpectDirectiveIndex?]`,
+> where the last element indexes a diagnostics list it supplied alongside them,
+> while the payload a client decodes carries
+> `[originalStart, originalLength, virtualStart, virtualLength, policy, unusedCode]`
+> with that index already resolved to a code. Do not reuse one decoder for both.
 
 ## Decoding a mapped source file
 
@@ -219,3 +269,5 @@ declares.
 - [Type-aware Oxlint](./oxlint_guide.md) — `settings.corsaOxlint` and rule authoring.
 - [Upstream pin](./corsa_upstream_dependency.md) — the Corsa revision these
   semantics are mirrored from.
+- [`ts-content-mapper`](https://github.com/sxzz/ts-content-mapper) — a library
+  for writing the mapper on the other end of this protocol.

--- a/src/core/corsa_client/src/api/content_mapper_tests.rs
+++ b/src/core/corsa_client/src/api/content_mapper_tests.rs
@@ -326,3 +326,102 @@ fn only_upstream_virtual_extensions_are_supported() {
     assert!(!is_supported_virtual_extension(".vue"));
     assert!(!is_supported_virtual_extension("ts"));
 }
+
+/// The `counter.demo` fixture from `sxzz/ts-content-mapper`'s example mapper.
+///
+/// ```text
+/// <template>
+///   <button>Count: {count}</button>
+/// </template>
+///
+/// <script>
+/// export const count: number = 1
+/// export const label = `Count: ${count}`
+/// </script>
+/// ```
+///
+/// Its mapper lifts the `<script>` body out with a single
+/// `MappedCodeBuilder(content).appendVerbatim(66, 137)`, which emits the one
+/// merged segment below — real mappers produce few, large verbatim runs rather
+/// than one segment per token.
+fn script_block_extraction() -> SpanMap {
+    SpanMap::new([SpanMapSegment::verbatim(0, 71, 66, 137)])
+}
+
+#[test]
+fn a_real_mappers_script_extraction_round_trips_both_ways() {
+    let map = script_block_extraction();
+
+    // `count` sits at offset 14 of the virtual text and 80 of the `.demo` file.
+    let to_original = map.virtual_to_original_span(TextRange::new(14, 19));
+    assert_eq!(to_original.range, TextRange::new(80, 85));
+    assert_eq!(to_original.fidelity, SpanMapFidelity::Exact);
+
+    let to_virtual = map.original_to_virtual_spans(TextRange::new(80, 85), SpanMapFeature::HOVER);
+    assert_eq!(to_virtual.len(), 1);
+    assert_eq!(to_virtual[0].range, TextRange::new(14, 19));
+    assert_eq!(to_virtual[0].fidelity, SpanMapFidelity::Exact);
+}
+
+#[test]
+fn text_outside_the_extracted_block_has_no_virtual_counterpart() {
+    let map = script_block_extraction();
+
+    // `{count}` inside `<template>` is never handed to the checker, so a lint
+    // or editor request there must not resolve to whatever the checker holds
+    // at that raw offset.
+    assert!(
+        map.original_to_virtual_positions(29, SpanMapFeature::HOVER)
+            .is_empty()
+    );
+    assert!(
+        map.original_to_virtual_spans(TextRange::new(29, 34), SpanMapFeature::HOVER)
+            .is_empty()
+    );
+}
+
+#[test]
+fn anchored_insertion_points_map_through_zero_length_segments() {
+    // `MappedCodeBuilder::appendAnchored` emits an atom whose original span is
+    // empty, defaulting to the definition and references features.
+    let anchor = SpanMapFeature::DEFINITION | SpanMapFeature::REFERENCES;
+    let map = SpanMap::new([
+        SpanMapSegment::verbatim(0, 12, 8, 20),
+        SpanMapSegment::new(12, 30, 20, 20, SpanMapKind::Atom).with_features(anchor),
+    ]);
+
+    let definitions = map.original_to_virtual_positions(20, SpanMapFeature::DEFINITION);
+
+    assert_eq!(
+        definitions,
+        [
+            super::MappedPosition {
+                position: 12,
+                fidelity: SpanMapFidelity::Exact,
+            },
+            super::MappedPosition {
+                position: 12,
+                fidelity: SpanMapFidelity::Atom,
+            },
+        ],
+        "the verbatim segment's exclusive end and the anchor both answer here"
+    );
+    assert!(
+        map.original_to_virtual_positions(20, SpanMapFeature::HOVER)
+            .iter()
+            .all(|projection| projection.fidelity == SpanMapFidelity::Exact),
+        "the anchor opted out of hover, so only the verbatim segment answers"
+    );
+}
+
+#[test]
+fn generated_text_with_no_original_counterpart_reports_no_fidelity() {
+    // A mapper's synthesized prologue — `MappedCodeBuilder::append` adds text
+    // without recording a segment for it.
+    let map = SpanMap::new([SpanMapSegment::verbatim(24, 95, 66, 137)]);
+
+    let mapped = map.virtual_to_original_position(8);
+
+    assert_eq!(mapped.fidelity, SpanMapFidelity::None);
+    assert_eq!(mapped.position, 0);
+}


### PR DESCRIPTION
Follow-up to #483, using [`sxzz/ts-content-mapper`](https://github.com/sxzz/ts-content-mapper)
— a library for writing the mapper on the other end of this protocol — as the
reference.

## Tests grounded in a real mapper

The span map cases from #483 used offsets invented for this port. The important
ones now use that package's example instead: its `counter.demo` fixture and the
single merged verbatim segment its mapper emits for the `<script>` body, which
is what `MappedCodeBuilder` actually produces once it collapses adjacent
verbatim runs (real mappers emit few, large segments — not one per token).

That covers two shapes the invented fixtures missed:

- **Text outside the extracted block.** `{count}` inside `<template>` is never
  handed to the checker, so it must project nowhere rather than onto whatever
  the checker holds at that raw offset.
- **`appendAnchored`'s zero-length original span.** A mapper anchors a generated
  declaration at an insertion point with an atom over an empty original range;
  a point query there is answered by both the preceding verbatim segment's
  exclusive end and the anchor, and honours the anchor's narrower feature set.

Cross-checking the protocol definitions also confirmed the decoder from #483 on
every field that matters: `SpanMapKind` / `SpanMapFeature` values, and the
`[virtualStart, virtualLength, originalStart, originalLength, kind, features?]`
segment tuple with omitted features meaning `All`.

## Docs

- The manifest example gains `compilerOptions` and `dynamicConfig`, with what
  each one does.
- A "Writing a mapper" section pointing at `ts-content-mapper`.
- A warning that the two protocols are **not** interchangeable. Span map
  segments are the same tuple on both sides, but diagnostic directives are not:
  a mapper sends
  `[originalStart, originalLength, virtualStart, virtualEnd, policy, unusedExpectDirectiveIndex?]`,
  where the last element indexes a diagnostics list it supplied alongside them,
  while the payload a client decodes carries
  `[originalStart, originalLength, virtualStart, virtualLength, policy, unusedCode]`
  with that index already resolved to a code. Verified against upstream
  `contentmapper/hostimpl.go` and `api/encoder/encoder.go` respectively.

No behaviour change — tests and documentation only. `corsa_client` is at 89
passing unit tests; `cargo clippy -D warnings`, `cargo fmt --all --check`, and
`vp fmt --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791171509&installation_model_id=422833&pr_number=484&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F484&signature=c9da5f5eada5a7e027858a68cd6291e8d03fb29b76ffcfecfd33a71b923189ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded content-mapper configuration examples and guidance.
  * Added instructions for writing mappers with `ts-content-mapper`.
  * Documented mapper protocol and API payload wire-format differences.
  * Added a related-resource link for further reference.

* **Tests**
  * Added coverage for script extraction and round-trip fidelity.
  * Added scenarios for unmapped template text, anchored insertions, feature filtering, and generated content fidelity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->