### PR TITLE
fix: resolve expression result types

### DIFF
--- a/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker.ts
@@ -89,6 +89,12 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
           return resolved;
         }
       }
+      if (kind === "TSNonNullExpression") {
+        const resolved = typeOfNonNullExpression(context, node as Node, this);
+        if (resolved) {
+          return resolved;
+        }
+      }
       if (kind === "MemberExpression") {
         const resolved = typeOfComputedMemberExpression(context, node as Node, this);
         if (resolved) {
@@ -182,6 +188,9 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
     getPropertiesOfType(type) {
       return sessionForContext(context).session.getPropertiesOfType(type);
     },
+    getIndexInfosOfType(type) {
+      return sessionForContext(context).session.getIndexInfosOfType(type);
+    },
     getSignaturesOfType(type, kind) {
       return sessionForContext(context).session.getSignaturesOfType(type, kind);
     },
@@ -198,6 +207,9 @@ export function createTypeChecker(context: ContextWithParserOptions): CorsaTypeC
     },
     getTypePredicateOfSignature(signature) {
       return sessionForContext(context).session.getTypePredicateOfSignature(signature);
+    },
+    getNonNullableType(type) {
+      return sessionForContext(context).session.getNonNullableType(type);
     },
     getBaseTypes(type) {
       // A constructor type in a superclass position resolves to its immediate
@@ -312,6 +324,7 @@ function primeImplementedTypesCacheFromNode(
 }
 
 const typeFlags = {
+  typeParameter: 1 << 19,
   union: 1 << 27,
   intersection: 1 << 28,
 } as const;
@@ -449,13 +462,15 @@ function typeOfCallExpression(
   }
   const rawArgs = (node as unknown as { readonly arguments?: unknown }).arguments;
   const args = Array.isArray(rawArgs) ? rawArgs.filter(isNode) : [];
+  const argumentTypes = args.map((arg) => typeInfoAtCallArgument(context, arg, checker));
+  const signatureFacts = checker.getCallSignatureFacts(
+    calleeType,
+    SignatureKind.Call,
+    argumentTypes.map((arg) => arg.texts),
+    explicitTypeArgumentTexts(context, node),
+  );
   const callSignature =
-    checker.getCallSignatureFacts(
-      calleeType,
-      SignatureKind.Call,
-      args.map((arg) => typeTextsAtCallArgument(context, arg, checker)),
-      explicitTypeArgumentTexts(context, node),
-    ).signature ?? checker.getSignaturesOfType(calleeType, SignatureKind.Call)[0];
+    signatureFacts.signature ?? checker.getSignaturesOfType(calleeType, SignatureKind.Call)[0];
   if (!callSignature) {
     return undefined;
   }
@@ -463,26 +478,42 @@ function typeOfCallExpression(
   if (!returnType) {
     return undefined;
   }
-  sessionForContext(context).session.rememberTypeLookupFromType(returnType, calleeType);
-  return returnType;
+  const inferredReturnType =
+    typeOfInferredGenericReturn(
+      returnType,
+      callSignature,
+      signatureFacts,
+      argumentTypes,
+      checker,
+    ) ?? returnType;
+  sessionForContext(context).session.rememberTypeLookupFromType(inferredReturnType, returnType);
+  sessionForContext(context).session.rememberTypeLookupFromType(inferredReturnType, calleeType);
+  return inferredReturnType;
 }
 
-function typeTextsAtCallArgument(
+interface CallArgumentTypeInfo {
+  readonly type?: CorsaType;
+  readonly texts: readonly string[];
+}
+
+function typeInfoAtCallArgument(
   context: ContextWithParserOptions,
   node: Node,
   checker: CorsaTypeCheckerShape,
-): readonly string[] {
+): CallArgumentTypeInfo {
   const values = new Set<string>();
   const nodeType = checker.getTypeAtLocation(node);
+  collectTexts(nodeType);
   collectTexts(nodeType ? (checker.getBaseTypeOfLiteralType(nodeType) ?? nodeType) : undefined);
   const symbol = checker.getSymbolAtLocation(node);
   const symbolType = symbol
     ? (checker.getTypeOfSymbol(symbol) ?? checker.getDeclaredTypeOfSymbol(symbol))
     : undefined;
+  collectTexts(symbolType);
   collectTexts(
     symbolType ? (checker.getBaseTypeOfLiteralType(symbolType) ?? symbolType) : undefined,
   );
-  return [...values];
+  return { type: nodeType ?? symbolType, texts: [...values] };
 
   function collectTexts(type: CorsaType | undefined): void {
     if (!type) {
@@ -494,6 +525,39 @@ function typeTextsAtCallArgument(
       }
     }
   }
+}
+
+function typeOfInferredGenericReturn(
+  returnType: CorsaType,
+  signature: CorsaSignature,
+  facts: { readonly expectedArgumentTypeTexts?: readonly (readonly string[])[] },
+  argumentTypes: readonly CallArgumentTypeInfo[],
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined {
+  if (signature.typeParameters.length === 0) {
+    return undefined;
+  }
+  if ((returnType.flags & typeFlags.typeParameter) === 0) {
+    return undefined;
+  }
+  const returnTexts = typeTexts(returnType, checker).map(normalizeTypeText);
+  if (returnTexts.length === 0) {
+    return undefined;
+  }
+  for (const [index, argument] of argumentTypes.entries()) {
+    if (!argument.type) {
+      continue;
+    }
+    const expectedTexts =
+      facts.expectedArgumentTypeTexts?.[index] ?? signature.parameterTypeTexts?.[index];
+    if (!expectedTexts) {
+      continue;
+    }
+    if (expectedTexts.map(normalizeTypeText).some((text) => returnTexts.includes(text))) {
+      return argument.type;
+    }
+  }
+  return undefined;
 }
 
 function explicitTypeArgumentTexts(
@@ -565,6 +629,24 @@ function typeOfAwaitExpression(
   return awaited;
 }
 
+function typeOfNonNullExpression(
+  context: ContextWithParserOptions,
+  node: Node,
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined {
+  const expression = childNode(node, "expression");
+  if (!expression) {
+    return undefined;
+  }
+  const expressionType = checker.getTypeAtLocation(expression);
+  if (!expressionType) {
+    return undefined;
+  }
+  const nonNullable = checker.getNonNullableType(expressionType) ?? expressionType;
+  sessionForContext(context).session.rememberTypeLookupFromType(nonNullable, expressionType);
+  return nonNullable;
+}
+
 function typeOfComputedMemberExpression(
   context: ContextWithParserOptions,
   node: Node,
@@ -586,7 +668,10 @@ function typeOfComputedMemberExpression(
   const propertyType = propertyName
     ? typeOfNamedProperty(objectType, propertyName, checker)
     : undefined;
-  const indexedType = propertyType ?? typeOfIndexedMember(objectType, property, checker);
+  const indexedType =
+    propertyType ??
+    typeOfIndexSignatureMember(objectType, property, checker) ??
+    typeOfIndexedMember(objectType, property, checker);
   if (indexedType) {
     sessionForContext(context).session.rememberTypeLookupFromType(indexedType, objectType);
   }
@@ -606,6 +691,20 @@ function typeOfNamedProperty(
     : undefined;
 }
 
+function typeOfIndexSignatureMember(
+  objectType: CorsaType,
+  property: Node,
+  checker: CorsaTypeCheckerShape,
+): CorsaType | undefined {
+  const propertyTypes = indexedPropertyTypes(property, checker);
+  for (const info of checker.getIndexInfosOfType(objectType)) {
+    if (indexKeyMatches(property, propertyTypes, info.keyType, checker)) {
+      return info.valueType;
+    }
+  }
+  return undefined;
+}
+
 function typeOfIndexedMember(
   objectType: CorsaType,
   property: Node,
@@ -620,13 +719,85 @@ function typeOfIndexedMember(
   if (index !== undefined && tupleLikeTypeText(text)) {
     return typeArguments[index];
   }
-  if (index !== undefined && arrayLikeTypeText(text)) {
+  const propertyTypes = indexedPropertyTypes(property, checker);
+  if (propertyCanIndexArray(propertyTypes, checker) && tupleLikeTypeText(text)) {
+    return syntheticCompoundType("union", typeArguments, checker);
+  }
+  if (
+    (index !== undefined || propertyCanIndexArray(propertyTypes, checker)) &&
+    !tupleLikeTypeText(text) &&
+    arrayLikeTypeText(text)
+  ) {
     return typeArguments[0];
   }
-  if (computedPropertyName(property) !== undefined && recordLikeTypeText(text)) {
+  if (
+    recordLikeTypeText(text) &&
+    (computedPropertyName(property) !== undefined ||
+      indexKeyMatches(property, propertyTypes, typeArguments[0], checker))
+  ) {
     return typeArguments[1];
   }
   return undefined;
+}
+
+function indexedPropertyTypes(
+  property: Node,
+  checker: CorsaTypeCheckerShape,
+): readonly CorsaType[] {
+  const type = checker.getTypeAtLocation(property);
+  if (!type) {
+    return [];
+  }
+  const base = checker.getBaseTypeOfLiteralType(type);
+  return uniqueTypesById(base ? [type, base] : [type]);
+}
+
+function propertyCanIndexArray(
+  propertyTypes: readonly CorsaType[],
+  checker: CorsaTypeCheckerShape,
+): boolean {
+  return propertyTypes.some((type) =>
+    typeTexts(type, checker).some((text) => normalizeTypeText(text) === "number"),
+  );
+}
+
+function indexKeyMatches(
+  property: Node,
+  propertyTypes: readonly CorsaType[],
+  keyType: CorsaType,
+  checker: CorsaTypeCheckerShape,
+): boolean {
+  if (
+    propertyTypes.some((propertyType) => checker.isTypeAssignableTo(propertyType, keyType) === true)
+  ) {
+    return true;
+  }
+  const keyTexts = typeTexts(keyType, checker).map(normalizeTypeText);
+  if (numericLiteralValue(property) !== undefined) {
+    return keyTexts.includes("number") || keyTexts.includes("string");
+  }
+  if (computedPropertyName(property) !== undefined) {
+    return keyTexts.includes("string");
+  }
+  return false;
+}
+
+function typeTexts(type: CorsaType, checker: CorsaTypeCheckerShape): readonly string[] {
+  const values = new Set<string>();
+  for (const text of type.texts ?? []) {
+    if (text) {
+      values.add(text);
+    }
+  }
+  const rendered = safeTypeToString(checker, type);
+  if (rendered) {
+    values.add(rendered);
+  }
+  return [...values];
+}
+
+function normalizeTypeText(text: string): string {
+  return text.split(/\s+/).join("");
 }
 
 function typeOfConditionalExpression(

--- a/src/bindings/nodejs/corsa_oxlint/ts/checker_conditional.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/checker_conditional.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CorsaType } from "./types";
 
 const mocks = vi.hoisted(() => {
+  const typeParameterFlag = 1 << 19;
   const knownType = {
     __corsaOxlintKind: "type",
     id: "known-type",
@@ -15,7 +16,115 @@ const mocks = vi.hoisted(() => {
     flags: 0,
     texts: ["boolean"],
   } as CorsaType;
+  const callableType = {
+    __corsaOxlintKind: "type",
+    id: "callable-type",
+    flags: 0,
+    texts: ['(value: "a") => Target'],
+  } as CorsaType;
+  const literalArgumentType = {
+    __corsaOxlintKind: "type",
+    id: "literal-argument-type",
+    flags: 0,
+    texts: ['"a"'],
+  } as CorsaType;
+  const widenedArgumentType = {
+    __corsaOxlintKind: "type",
+    id: "widened-argument-type",
+    flags: 0,
+    texts: ["string"],
+  } as CorsaType;
+  const callReturnType = {
+    __corsaOxlintKind: "type",
+    id: "call-return-type",
+    flags: 0,
+    texts: ["Target"],
+  } as CorsaType;
+  const genericCallableType = {
+    __corsaOxlintKind: "type",
+    id: "generic-callable-type",
+    flags: 0,
+    texts: ["<T>(value: T) => T"],
+  } as CorsaType;
+  const genericReturnType = {
+    __corsaOxlintKind: "type",
+    id: "generic-return-type",
+    flags: typeParameterFlag,
+    texts: ["T"],
+  } as CorsaType;
+  const nullableType = {
+    __corsaOxlintKind: "type",
+    id: "nullable-type",
+    flags: 0,
+    texts: ["Target | undefined"],
+  } as CorsaType;
+  const nonNullableType = {
+    __corsaOxlintKind: "type",
+    id: "non-nullable-type",
+    flags: 0,
+    texts: ["Target"],
+  } as CorsaType;
+  const registryType = {
+    __corsaOxlintKind: "type",
+    id: "registry-type",
+    flags: 0,
+    texts: ["Registry"],
+  } as CorsaType;
+  const keyType = {
+    __corsaOxlintKind: "type",
+    id: "key-type",
+    flags: 0,
+    texts: ["string"],
+  } as CorsaType;
+  const indexedValueType = {
+    __corsaOxlintKind: "type",
+    id: "indexed-value-type",
+    flags: 0,
+    texts: ["Plain"],
+  } as CorsaType;
+  const tupleType = {
+    __corsaOxlintKind: "type",
+    id: "tuple-type",
+    flags: 0,
+    texts: ["readonly [Target, Plain]"],
+  } as CorsaType;
+  const tupleTargetType = {
+    __corsaOxlintKind: "type",
+    id: "tuple-target-type",
+    flags: 0,
+    texts: ["Target"],
+  } as CorsaType;
+  const tuplePlainType = {
+    __corsaOxlintKind: "type",
+    id: "tuple-plain-type",
+    flags: 0,
+    texts: ["Plain"],
+  } as CorsaType;
+  const numberIndexType = {
+    __corsaOxlintKind: "type",
+    id: "number-index-type",
+    flags: 0,
+    texts: ["number"],
+  } as CorsaType;
   return {
+    types: {
+      callableType,
+      literalArgumentType,
+      widenedArgumentType,
+      callReturnType,
+      genericCallableType,
+      genericReturnType,
+      nullableType,
+      nonNullableType,
+      registryType,
+      keyType,
+      indexedValueType,
+      tupleType,
+      tupleTargetType,
+      tuplePlainType,
+      numberIndexType,
+    },
+    signature: { id: "signature-1", flags: 0, typeParameters: [], parameters: [] },
     session: {
       getTypeAtSourceRange: vi.fn(
         (
@@ -28,9 +137,71 @@ const mocks = vi.hoisted(() => {
           if (nodeKind === "ConditionalExpression") {
             return fallbackType;
           }
+          if (position === 0 && nodeKind === "Identifier") {
+            return callableType;
+          }
+          if (position === 7 && nodeKind === "Literal") {
+            return literalArgumentType;
+          }
+          if (position === 100 && nodeKind === "Identifier") {
+            return nullableType;
+          }
+          if (position === 300 && nodeKind === "Identifier") {
+            return genericCallableType;
+          }
+          if (position === 309 && nodeKind === "Identifier") {
+            return callReturnType;
+          }
+          if (position === 200 && nodeKind === "Identifier") {
+            return registryType;
+          }
+          if (position === 209 && nodeKind === "Identifier") {
+            return keyType;
+          }
+          if (position === 400 && nodeKind === "Identifier") {
+            return tupleType;
+          }
+          if (position === 406 && nodeKind === "Identifier") {
+            return numberIndexType;
+          }
           return position === 7 ? knownType : undefined;
         },
       ),
+      getBaseTypeOfLiteralType: vi.fn((type: CorsaType) =>
+        type.id === "literal-argument-type" ? widenedArgumentType : undefined,
+      ),
+      getCallSignatureFacts: vi.fn((type: CorsaType) => ({
+        signature:
+          type.id === "generic-callable-type"
+            ? {
+                id: "generic-signature",
+                flags: 0,
+                typeParameters: ["generic-return-type"],
+                parameters: [],
+                parameterTypeTexts: [["T"]],
+              }
+            : { id: "signature-1", flags: 0, typeParameters: [], parameters: [] },
+      })),
+      getDeclaredTypeOfSymbol: vi.fn(() => undefined),
+      getIndexInfosOfType: vi.fn(() => [
+        { keyType, valueType: indexedValueType, isReadonly: false },
+      ]),
+      getNonNullableType: vi.fn((type: CorsaType) =>
+        type.id === "nullable-type" ? nonNullableType : undefined,
+      ),
+      getPropertiesOfType: vi.fn(() => []),
+      getReturnTypeOfSignature: vi.fn((signature: { id: string }) =>
+        signature.id === "generic-signature" ? genericReturnType : callReturnType,
+      ),
+      getSignaturesOfType: vi.fn(() => []),
+      getSymbolAtPosition: vi.fn(() => undefined),
+      getTypeArguments: vi.fn((type: CorsaType) =>
+        type.id === "tuple-type" ? [tupleTargetType, tuplePlainType] : [],
+      ),
+      getTypeOfSymbol: vi.fn(() => undefined),
+      isTypeAssignableTo: vi.fn((source: CorsaType, target: CorsaType) => source.id === target.id),
+      rememberTypeLookupFromType: vi.fn(),
+      typeToString: vi.fn((type: CorsaType) => type.texts[0] ?? type.id),
     },
   };
 });
@@ -46,7 +217,7 @@ const { createTypeChecker } = await import("./checker");
 
 describe("createTypeChecker conditional type locations", () => {
   beforeEach(() => {
-    mocks.session.getTypeAtSourceRange.mockClear();
+    vi.clearAllMocks();
   });
 
   it("does not collapse a conditional expression when either branch is unresolved", () => {
@@ -72,5 +243,112 @@ describe("createTypeChecker conditional type locations", () => {
       "Identifier",
       "Identifier",
     ]);
+  });
+
+  it("passes literal and widened argument texts to signature facts", () => {
+    const sourceText = 'choose("a")';
+    const checker = createTypeChecker({
+      cwd: "/workspace",
+      filename: "/workspace/src/index.ts",
+      sourceCode: { text: sourceText },
+      settings: {},
+    } as never);
+
+    const type = checker.getTypeAtLocation({
+      type: "CallExpression",
+      range: [0, sourceText.length],
+      callee: { type: "Identifier", name: "choose", range: [0, 6] },
+      arguments: [{ type: "Literal", value: "a", range: [7, 10] }],
+    } as never);
+
+    expect(type).toBe(mocks.types.callReturnType);
+    expect(mocks.session.getCallSignatureFacts).toHaveBeenCalledWith(
+      mocks.types.callableType,
+      0,
+      [[`"a"`, "string"]],
+      [],
+    );
+  });
+
+  it("substitutes generic return types from matching argument types", () => {
+    const sourceText = "identity(target)";
+    const checker = createTypeChecker({
+      cwd: "/workspace",
+      filename: "/workspace/src/index.ts",
+      sourceCode: { text: sourceText },
+      settings: {},
+    } as never);
+
+    const type = checker.getTypeAtLocation({
+      type: "CallExpression",
+      range: [300, 316],
+      callee: { type: "Identifier", name: "identity", range: [300, 308] },
+      arguments: [{ type: "Identifier", name: "target", range: [309, 315] }],
+    } as never);
+
+    expect(type).toBe(mocks.types.callReturnType);
+    expect(mocks.session.getCallSignatureFacts).toHaveBeenCalledWith(
+      mocks.types.genericCallableType,
+      0,
+      [["Target"]],
+      [],
+    );
+  });
+
+  it("removes nullable parts from non-null assertion expressions", () => {
+    const checker = createTypeChecker({
+      cwd: "/workspace",
+      filename: "/workspace/src/index.ts",
+      sourceCode: { text: "value!" },
+      settings: {},
+    } as never);
+
+    const type = checker.getTypeAtLocation({
+      type: "TSNonNullExpression",
+      range: [100, 106],
+      expression: { type: "Identifier", name: "value", range: [100, 105] },
+    } as never);
+
+    expect(type).toBe(mocks.types.nonNullableType);
+    expect(mocks.session.getNonNullableType).toHaveBeenCalledWith(mocks.types.nullableType);
+  });
+
+  it("resolves computed members through index signature value types", () => {
+    const checker = createTypeChecker({
+      cwd: "/workspace",
+      filename: "/workspace/src/index.ts",
+      sourceCode: { text: "registry[key]" },
+      settings: {},
+    } as never);
+
+    const type = checker.getTypeAtLocation({
+      type: "MemberExpression",
+      computed: true,
+      range: [200, 213],
+      object: { type: "Identifier", name: "registry", range: [200, 208] },
+      property: { type: "Identifier", name: "key", range: [209, 212] },
+    } as never);
+
+    expect(type).toBe(mocks.types.indexedValueType);
+    expect(mocks.session.getIndexInfosOfType).toHaveBeenCalledWith(mocks.types.registryType);
+  });
+
+  it("resolves non-literal tuple numeric access as an element union", () => {
+    const checker = createTypeChecker({
+      cwd: "/workspace",
+      filename: "/workspace/src/index.ts",
+      sourceCode: { text: "tuple[index]" },
+      settings: {},
+    } as never);
+
+    const type = checker.getTypeAtLocation({
+      type: "MemberExpression",
+      computed: true,
+      range: [400, 412],
+      object: { type: "Identifier", name: "tuple", range: [400, 405] },
+      property: { type: "Identifier", name: "index", range: [406, 411] },
+    } as never);
+
+    expect(type?.texts).toEqual(["Target | Plain"]);
   });
 });

--- a/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/parser_services.ts
@@ -186,6 +186,9 @@ function createEslintTypeChecker(
     getPropertiesOfType(type) {
       return asReadonlyArray(callChecker(source, "getPropertiesOfType", type));
     },
+    getIndexInfosOfType(type) {
+      return asReadonlyArray(callChecker(source, "getIndexInfosOfType", type));
+    },
     getSignaturesOfType(type, kind) {
       return asReadonlyArray(callChecker(source, "getSignaturesOfType", type, kind));
     },
@@ -197,6 +200,9 @@ function createEslintTypeChecker(
     },
     getTypePredicateOfSignature(signature) {
       return callChecker(source, "getTypePredicateOfSignature", signature);
+    },
+    getNonNullableType(type) {
+      return callChecker(source, "getNonNullableType", type) ?? type;
     },
     getBaseTypes(type) {
       return asReadonlyArray(callChecker(source, "getBaseTypes", type));

--- a/src/bindings/nodejs/corsa_oxlint/ts/session.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/session.ts
@@ -12,6 +12,7 @@ import {
 
 import type {
   CorsaCallSignatureFacts,
+  CorsaIndexInfo,
   CorsaJsDocTagInfo,
   CorsaNode,
   CorsaSignature,
@@ -841,6 +842,18 @@ export class CorsaProjectSession {
     );
   }
 
+  getIndexInfosOfType(type: CorsaType): readonly CorsaIndexInfo[] {
+    return this.withMissingTypeHandleFallback<readonly CorsaIndexInfo[]>(type, [], () =>
+      this.rememberIndexInfos(
+        this.client().callJson<readonly CorsaIndexInfo[] | null>("getIndexInfosOfType", {
+          snapshot: this.#snapshot,
+          project: this.projectIdForType(type),
+          type: type.id,
+        }) ?? [],
+      ),
+    );
+  }
+
   getSignaturesOfType(type: CorsaType, kind: number): readonly CorsaSignature[] {
     return this.withMissingTypeHandleFallback<readonly CorsaSignature[]>(type, [], () => {
       const source = this.sourceContextForType(type);
@@ -938,6 +951,10 @@ export class CorsaProjectSession {
       this.rememberType(predicate.type);
     }
     return predicate;
+  }
+
+  getNonNullableType(type: CorsaType): CorsaType | undefined {
+    return this.callType("getNonNullableType", type);
   }
 
   getBaseTypes(type: CorsaType): readonly CorsaType[] {
@@ -1274,6 +1291,14 @@ export class CorsaProjectSession {
       this.rememberType(type);
     }
     return types;
+  }
+
+  private rememberIndexInfos<T extends readonly CorsaIndexInfo[]>(infos: T): T {
+    for (const info of infos) {
+      this.rememberType(info.keyType);
+      this.rememberType(info.valueType);
+    }
+    return infos;
   }
 
   private rememberTypeSource(type: CorsaType | undefined, handle: string | undefined): void {

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -764,6 +764,172 @@ describe("corsa oxlint type locations", () => {
     });
   });
 
+  integrationCase(
+    "resolves expression result types for indexed, non-null, overload, and generic calls",
+    () => {
+      const seen: Record<string, { readonly checker?: string; readonly services?: string }> = {};
+      const expected: Record<string, string> = {
+        target: "Target",
+        "holder.plain": "Target",
+        "make()": "Target",
+        "targets[0]": "Target",
+        "grid[0][1]": "Target",
+        'record["x"]': "Plain",
+        'byType("s")': "Target",
+        "byType(1)": "Plain",
+        "byArity()": "Target",
+        "byArity(1)": "Plain",
+        'classRegistry["x"]': "Plain",
+        'stringRegistry["x"]': "Plain",
+        "numberRegistry[0]": "Plain",
+        "targets[index]": "Target",
+        "grid[index][0]": "Target",
+        "tuple[index]": "Plain | Target",
+        "record[key]": "Plain",
+        "maybe()!": "Target",
+        "targets[0]!": "Target",
+        'byLiteral("a")': "Target",
+        'byLiteral("b")': "Plain",
+        'byLiteralReversed("a")': "Target",
+        'byLiteralReversed("b")': "Plain",
+        "identity(target)": "Target",
+      };
+      const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+      const rule = createRule({
+        name: "expression-result-types",
+        meta: {
+          type: "problem",
+          docs: {
+            description: "exercise expression result type lookup parity",
+            requiresTypeChecking: true,
+          },
+          messages: {
+            unexpected: "unexpected",
+          },
+          schema: [],
+        },
+        defaultOptions: [],
+        create(context: any) {
+          const services = OxlintUtils.getParserServices(context);
+          const checker = services.program.getTypeChecker();
+          return {
+            CallExpression(node: any) {
+              if (node.callee?.type !== "Identifier" || node.callee.name !== "probe") {
+                return;
+              }
+              const argument = node.arguments?.[0];
+              if (!argument) {
+                return;
+              }
+              const source = context.sourceCode.getText(argument);
+              const checkerType = checker.getTypeAtLocation(argument);
+              const servicesType = services.getTypeAtLocation(argument);
+              seen[source] = {
+                checker: checkerType ? checker.typeToString(checkerType) : undefined,
+                services: servicesType ? checker.typeToString(servicesType) : undefined,
+              };
+            },
+          };
+        },
+      });
+
+      const tester = new RuleTester({ languageOptions: { sourceType: "module" } });
+      tester.run("expression-result-types", rule as any, {
+        valid: [
+          {
+            code: [
+              "class Target { marker = 1; }",
+              "class Plain { other = 2; }",
+              "class Holder { plain: Target = new Target(); }",
+              "class ClassRegistry { [key: string]: Plain; }",
+              "interface StringRegistry { [key: string]: Plain; }",
+              "interface NumberRegistry { [index: number]: Plain; }",
+              "function make(): Target { return new Target(); }",
+              "function maybe(): Target | undefined { return new Target(); }",
+              'function byLiteral(kind: "a"): Target;',
+              'function byLiteral(kind: "b"): Plain;',
+              "function byLiteral(kind: string): Target | Plain {",
+              '  return kind === "a" ? new Target() : new Plain();',
+              "}",
+              'function byLiteralReversed(kind: "b"): Plain;',
+              'function byLiteralReversed(kind: "a"): Target;',
+              "function byLiteralReversed(kind: string): Target | Plain {",
+              '  return kind === "a" ? new Target() : new Plain();',
+              "}",
+              "function byType(kind: string): Target;",
+              "function byType(kind: number): Plain;",
+              "function byType(kind: string | number): Target | Plain {",
+              '  return typeof kind === "string" ? new Target() : new Plain();',
+              "}",
+              "function byArity(): Target;",
+              "function byArity(count: number): Plain;",
+              "function byArity(count?: number): Target | Plain {",
+              "  return count === undefined ? new Target() : new Plain();",
+              "}",
+              "function identity<T>(value: T): T { return value; }",
+              "function probe(_value: unknown): void {}",
+              "const target = new Target();",
+              "const holder = new Holder();",
+              "const targets = [new Target()];",
+              "declare const grid: Target[][];",
+              "declare const tuple: readonly [Target, Plain];",
+              "declare const index: number;",
+              "declare const key: string;",
+              "declare const classRegistry: ClassRegistry;",
+              "declare const stringRegistry: StringRegistry;",
+              "declare const numberRegistry: NumberRegistry;",
+              "declare const record: Record<string, Plain>;",
+              "probe(target);",
+              "probe(holder.plain);",
+              "probe(make());",
+              "probe(targets[0]);",
+              "probe(grid[0][1]);",
+              'probe(record["x"]);',
+              'probe(byType("s"));',
+              "probe(byType(1));",
+              "probe(byArity());",
+              "probe(byArity(1));",
+              'probe(classRegistry["x"]);',
+              'probe(stringRegistry["x"]);',
+              "probe(numberRegistry[0]);",
+              "probe(targets[index]);",
+              "probe(grid[index][0]);",
+              "probe(tuple[index]);",
+              "probe(record[key]);",
+              "probe(maybe()!);",
+              "probe(targets[0]!);",
+              'probe(byLiteral("a"));',
+              'probe(byLiteral("b"));',
+              'probe(byLiteralReversed("a"));',
+              'probe(byLiteralReversed("b"));',
+              "probe(identity(target));",
+            ].join("\n"),
+            settings: {
+              corsaOxlint: {
+                parserOptions: {
+                  corsa: {
+                    executable: realCorsaBinary,
+                    mode: "jsonrpc",
+                  },
+                },
+              },
+            },
+          },
+        ],
+        invalid: [],
+      });
+
+      expect(seen).toEqual(
+        Object.fromEntries(
+          Object.entries(expected).map(([source, type]) => [
+            source,
+            { checker: type, services: type },
+          ]),
+        ),
+      );
+    },
+  );
+
   integrationCase("resolves modified property definition nodes to their declared types", () => {
     const seen: Record<string, { readonly node?: string; readonly key?: string }> = {};
     const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);

--- a/src/bindings/nodejs/corsa_oxlint/ts/types.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/types.ts
@@ -97,6 +97,12 @@ export interface CorsaSignature {
   readonly typeParameterDefaultTexts?: readonly string[];
 }
 
+export interface CorsaIndexInfo {
+  readonly keyType: CorsaType;
+  readonly valueType: CorsaType;
+  readonly isReadonly: boolean;
+}
+
 export interface CorsaCallSignatureFacts {
   readonly signature?: CorsaSignature;
   readonly expectedArgumentTypeTexts?: readonly (readonly string[])[];
@@ -159,6 +165,7 @@ export interface CorsaTypeCheckerShape {
   typeToString(type: CorsaType, enclosingDeclaration?: Node | CorsaNode, flags?: number): string;
   getBaseTypeOfLiteralType(type: CorsaType): CorsaType | undefined;
   getPropertiesOfType(type: CorsaType): readonly CorsaSymbol[];
+  getIndexInfosOfType(type: CorsaType): readonly CorsaIndexInfo[];
   getSignaturesOfType(type: CorsaType, kind: SignatureKind): readonly CorsaSignature[];
   getCallSignatureFacts(
     type: CorsaType,
@@ -168,6 +175,7 @@ export interface CorsaTypeCheckerShape {
   ): CorsaCallSignatureFacts;
   getReturnTypeOfSignature(signature: CorsaSignature): CorsaType | undefined;
   getTypePredicateOfSignature(signature: CorsaSignature): CorsaTypePredicate | undefined;
+  getNonNullableType(type: CorsaType): CorsaType | undefined;
   getBaseTypes(type: CorsaType): readonly CorsaType[];
   getImplementedTypes(node: Node | CorsaNode): readonly CorsaType[];
   getImplementedTypesOfType(type: CorsaType): readonly CorsaType[];


### PR DESCRIPTION
## Summary

- Fix getTypeAtLocation for computed index signatures, non-null assertions, overloaded calls, and generic calls.
- Resolve call signatures from the actual call expression source range before falling back to type-text signature scoring.
- Add index-info and non-nullable checker plumbing plus a real-runtime integration fixture for issue #490.

Fixes #490

## Validation

- [x] Tests or checks run locally
- [ ] Not applicable

Local:
- vp fmt --check
- cargo fmt --all --check
- git diff --check
- vp check --no-fmt
- vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_node/ts/index.test.ts src/bindings/nodejs/corsa_oxlint/ts/checker_conditional.test.ts
- vp run -w test_ts
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings

CI:
- Real Corsa TypeScript integration tests should exercise the new full fixture with CORSA_REQUIRE_INTEGRATION=1.

## Checklist

- [x] Scope is limited to the described change
- [x] Documentation or templates were updated when needed
- [x] Follow-up work is tracked in an issue

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791551158&installation_model_id=422833&pr_number=492&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F492&signature=5574559954cd69592d60bdffe0079d9dbeaf264defc19e1f4c20e4ab5ff1dd57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved type resolution for non-null assertions, generic calls, overloads, and computed member access.
  - Added support for resolving array and record index signatures, including key and value type metadata.
  - Exposed APIs for retrieving index-signature information and non-nullable types.

- **Tests**
  - Added coverage for indexed access, nested indexing, overload selection, generic calls, and non-null expressions.
  - Added integration checks to ensure checker and parser-service results remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->