### PR TITLE
test: cover non-nullable checker accessor

### DIFF
--- a/docs/oxlint_guide.md
+++ b/docs/oxlint_guide.md
@@ -96,10 +96,10 @@ export const noStringPlusNumber = createRule({
 Setting `requiresTypeChecking: true` is what tells the framework a rule needs
 the type-aware path. The checker object behaves like the TypeScript checker
 (`getTypeAtLocation`, `typeToString`, `getBaseTypeOfLiteralType`,
-`getJsDocTags`, `isTypeAssignableTo`, …), but the types come from the pinned
-Corsa binary. Call-like expressions resolve through the callee's call
-signatures and `await` expressions unwrap their promise reference, mirroring
-what `getTypeAtLocation` means in the real TypeScript API.
+`getNonNullableType`, `getJsDocTags`, `isTypeAssignableTo`, …), but the types
+come from the pinned Corsa binary. Call-like expressions resolve through the
+callee's call signatures and `await` expressions unwrap their promise
+reference, mirroring what `getTypeAtLocation` means in the real TypeScript API.
 
 ## Configuration: `settings.corsaOxlint`
 

--- a/src/bindings/nodejs/corsa_oxlint/ts/project_scoped_requests.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/project_scoped_requests.test.ts
@@ -43,6 +43,7 @@ const TRAVERSAL_ACCESSORS = [
   // only falls through to the direct endpoint when that yields nothing.
   "getConstraintOfTypeParameter",
   "getPropertiesOfType",
+  "getNonNullableType",
   "getBaseTypes",
 ] as const;
 

--- a/src/bindings/nodejs/corsa_oxlint/ts/public_types.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/public_types.test.ts
@@ -200,7 +200,14 @@ describe("corsa oxlint public types", () => {
             acceptClass(node);
           },
           MethodDefinition(node) {
-            services.getTypeAtLocation(node.value);
+            const type = services.getTypeAtLocation(node.value);
+            const checker = services.program.getTypeChecker();
+            if (type) {
+              const nonNullable = checker.getNonNullableType(type);
+              if (nonNullable) {
+                checker.getPropertiesOfType(nonNullable);
+              }
+            }
           },
           NewExpression(node) {
             acceptNewExpression(node);

--- a/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
+++ b/src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts
@@ -2090,6 +2090,121 @@ describe("corsa oxlint type locations", () => {
   });
 
   /**
+   * Issue #491: rules need the same nullish-stripping route TypeScript exposes
+   * before they can ask for properties shared by non-nullish union members.
+   */
+  integrationCase("exposes non-nullable union types to type-aware rules", () => {
+    const seen: Record<
+      string,
+      {
+        readonly accessorType: string;
+        readonly nonNullableMembers: readonly string[];
+        readonly nonNullableProperties: readonly string[];
+        readonly originalProperties: readonly string[];
+      }
+    > = {};
+    const createRule = OxlintUtils.RuleCreator((name) => `https://example.com/rules/${name}`);
+    const rule = createRule({
+      name: "non-nullable-union-types",
+      meta: {
+        type: "problem",
+        docs: {
+          description: "exercise non-nullable type lookup",
+          requiresTypeChecking: true,
+        },
+        messages: { unexpected: "unexpected" },
+        schema: [],
+      },
+      defaultOptions: [],
+      create(context: any) {
+        const services = OxlintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        const names = (type: any): readonly string[] =>
+          checker.getPropertiesOfType(type).map((symbol: any) => symbol.name);
+        return {
+          CallExpression(node: any) {
+            if (node.callee.type !== "Identifier" || node.callee.name !== "probe") {
+              return;
+            }
+            const arg = node.arguments[0];
+            const type = checker.getTypeAtLocation(arg);
+            if (!type) {
+              return;
+            }
+            const nonNullable = checker.getNonNullableType(type);
+            if (!nonNullable) {
+              return;
+            }
+            seen[context.sourceCode.getText(arg)] = {
+              accessorType: typeof checker.getNonNullableType,
+              nonNullableMembers: checker
+                .getTypesOfType(nonNullable)
+                .map((member: any) => checker.typeToString(member)),
+              nonNullableProperties: names(nonNullable),
+              originalProperties: names(type),
+            };
+          },
+        };
+      },
+    });
+
+    const tester = new RuleTester();
+    tester.run("non-nullable-union-types", rule as any, {
+      valid: [
+        {
+          code: [
+            "class Alpha {",
+            "  shared = 1;",
+            "  onlyAlpha = 2;",
+            "}",
+            "class Beta {",
+            "  shared = 1;",
+            "  onlyBeta = 2;",
+            "}",
+            "function probe(_value: unknown): void {}",
+            "declare const required: Alpha | Beta;",
+            "declare const optional: Alpha | Beta | undefined;",
+            "declare const nullable: Alpha | Beta | null;",
+            "declare const voidish: Alpha | Beta | void;",
+            "probe(required);",
+            "probe(optional);",
+            "probe(nullable);",
+            "probe(voidish);",
+          ].join("\n"),
+          settings: {
+            corsaOxlint: {
+              parserOptions: {
+                corsa: {
+                  executable: realCorsaBinary,
+                  mode: "jsonrpc",
+                },
+              },
+            },
+          },
+        },
+      ],
+      invalid: [],
+    });
+
+    expect(seen.required?.accessorType).toBe("function");
+    expect(seen.required?.originalProperties).toEqual(["shared"]);
+    expect(seen.required?.nonNullableMembers).toEqual(expect.arrayContaining(["Alpha", "Beta"]));
+    expect(seen.required?.nonNullableProperties).toEqual(["shared"]);
+    expect(seen.optional?.originalProperties).toEqual([]);
+    expect(seen.optional?.nonNullableMembers).toEqual(expect.arrayContaining(["Alpha", "Beta"]));
+    expect(seen.optional?.nonNullableMembers).not.toContain("undefined");
+    expect(seen.optional?.nonNullableProperties).toEqual(["shared"]);
+    expect(seen.nullable?.originalProperties).toEqual([]);
+    expect(seen.nullable?.nonNullableMembers).toEqual(expect.arrayContaining(["Alpha", "Beta"]));
+    expect(seen.nullable?.nonNullableMembers).not.toContain("null");
+    expect(seen.nullable?.nonNullableProperties).toEqual(["shared"]);
+    expect(seen.voidish?.originalProperties).toEqual([]);
+    expect(seen.voidish?.nonNullableMembers).toEqual(expect.arrayContaining(["Alpha", "Beta"]));
+    expect(seen.voidish?.nonNullableMembers).not.toContain("void");
+    expect(seen.voidish?.nonNullableProperties).toEqual(["shared"]);
+  });
+
+  /**
    * Issue #441: on a stable TypeScript 7 runtime the construct signature of a
    * class with an explicit constructor came back with `parameterSymbols`
    * undefined, because that runtime's compact declaration handle carries no


### PR DESCRIPTION
## Summary
- add a dedicated regression for `getNonNullableType` on optional and nullable unions
- include the accessor in the project-scoped checker request contract
- document the accessor in the type-aware rule guide

## Root Cause
The underlying accessor already exists on the current checker surface, but issue #491 did not have a direct public regression. That left this bug family exposed to another project-less type-handle regression whenever a new checker endpoint was added.

## Validation
- `vp fmt`
- `cargo fmt --all --check`
- `vp check --no-fmt`
- `vp test run --config ./vite.config.ts src/bindings/nodejs/corsa_oxlint/ts/public_types.test.ts src/bindings/nodejs/corsa_oxlint/ts/project_scoped_requests.test.ts src/bindings/nodejs/corsa_oxlint/ts/type_location.test.ts`

Fixes #491

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/corsa-bind/pr/493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791602008&installation_model_id=422833&pr_number=493&repository=ubugeeei-prod%2Fcorsa-bind&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fcorsa-bind%2Fpull%2F493&signature=be8146e9dcb131b84fdcbfd3be4e7cf2e315c6a076e3ae8178fca73c4efc1854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the TypeScript checker guide to include support for retrieving non-nullable types.

- **Tests**
  - Expanded coverage to verify non-nullable type handling for optional and nullable unions.
  - Added validation that type-aware rules can inspect properties and member types after null and undefined values are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->